### PR TITLE
Espn url before 2018

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ffscrapr
 Title: API Client for Fantasy Football League Platforms
-Version: 1.4.5.02
+Version: 1.4.5.03
 Authors@R: 
     c(person(given = "Tan",
              family = "Ho",

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - `ff_league()` for MFL now returns draft type (e.g. "email draft", "live auction") if the field is set.
 - `ff_league()` for MFL now returns draft player pool (e.g. "Rookie", "Veteran", "Both") if the field is set. (These three changes fix #311, thanks @maat7043!)
 - `ff_schedule()` for ESPN now credits a bye team with a win instead of causing an error.
+- `espn_getendpoint()` no longer returns an error for seasons prior to 2018.
 
 ---
 

--- a/R/espn_api.R
+++ b/R/espn_api.R
@@ -39,25 +39,25 @@ espn_getendpoint <- function(conn, ..., x_fantasy_filter = NULL) {
 
   if (as.numeric(conn$season) < 2018) {
     url_query <- httr::modify_url(
-      url = glue::glue("https://fantasy.espn.com/apis/v3/games/ffl/leagueHistory/{conn$league_id}"),
-      query = list(
-        seasonId = conn$season,
-        ...
-      )
+      url = glue::glue("https://fantasy.espn.com/apis/v3/games/ffl/leagueHistory/{conn$league_id}?seasonId={conn$season}"),
+      query = list(...)
     )
   }
 
   if (as.numeric(conn$season) >= 2018) {
-    base_url <- glue::glue("https://fantasy.espn.com/apis/v3/games/ffl/seasons/{conn$season}/segments/0/leagues/{conn$league_id}")
+    url_query <- httr::modify_url(
+      url = glue::glue("https://fantasy.espn.com/apis/v3/games/ffl/seasons/{conn$season}/segments/0/leagues/{conn$league_id}"),
+      query = list(...)
+    )
   }
 
-  # PREP URL
-  url_query <- httr::modify_url(
-    url = base_url,
-    query = list(...)
-  )
+  endpoint_raw <- espn_getendpoint_raw(conn, url_query, xff)
 
-  espn_getendpoint_raw(conn, url_query, xff)
+  if (as.numeric(conn$season) < 2018) {
+    endpoint_raw$content <-  endpoint_raw$content[[1]]
+  }
+
+  return(endpoint_raw)
 }
 
 #' GET ESPN endpoint (raw)

--- a/R/espn_starters.R
+++ b/R/espn_starters.R
@@ -18,6 +18,9 @@
 #'
 #' @export
 ff_starters.espn_conn <- function(conn, weeks = 1:17, ...) {
+
+  if (conn$season < 2019) stop("Starting lineups not available before 2019")
+
   checkmate::assert_numeric(weeks)
 
   max_week <- .espn_week_checkmax(conn)

--- a/R/espn_starters.R
+++ b/R/espn_starters.R
@@ -19,7 +19,7 @@
 #' @export
 ff_starters.espn_conn <- function(conn, weeks = 1:17, ...) {
 
-  if (conn$season < 2019) stop("Starting lineups not available before 2019")
+  if (conn$season < 2018) stop("Starting lineups not available before 2018")
 
   checkmate::assert_numeric(weeks)
 


### PR DESCRIPTION
The modify_url was looking for a base_url object for leagues prior to 2018 so now each url_query is completely defined in separate if statements. Objects prior to 2018 had an extra layer that needed to be extracted to line up with the 2018+ objects.
No starters prior to 2018. 