### PR TITLE
Convert all lists to tibbles before calling `unnest_wider()`

### DIFF
--- a/R/mfl_scoring.R
+++ b/R/mfl_scoring.R
@@ -39,8 +39,8 @@ ff_scoring.mfl_conn <- function(conn) {
         .data$vec_depth == 4 ~ purrr::map_depth(.data$rule, -2, `[[`, 1)
       ),
       rule = dplyr::case_when(
-        .data$vec_depth == 4 ~ purrr::map(.data$rule, dplyr::bind_rows),
-        TRUE ~ .data$rule
+        .data$vec_depth == 3 ~ purrr::map(.data$rule, dplyr::bind_rows),
+        .data$vec_depth == 4 ~ purrr::map(.data$rule, list_bind_rows)
       )
     ) %>%
     dplyr::select(-.data$vec_depth) %>%
@@ -66,6 +66,10 @@ ff_scoring.mfl_conn <- function(conn) {
     )
 
   return(df)
+}
+
+list_bind_rows <- function(x) {
+  dplyr::bind_rows(!!!x)
 }
 
 #' Parse the scoring rule chars into numeric.


### PR DESCRIPTION
Hi @tanho63,

I am working on some improvements to `tidyr::unnest_wider()`, and your package was seen in the revdepchecks. I haven't pushed the changes yet, but I can ping you and give you a link to the tidyr PR when I do. Feel free to let this PR sit around if you want to wait to see the tidyr PR, but this will also work with the CRAN version of tidyr too.

It seems like right here, you convert lists with depth 4 to a tibble, but lists with depth 3 are left as lists. Then you take that `rule` list-col containing a mix of tibbles and lists and `unnest_wider()` it.
https://github.com/ffverse/ffscrapr/blob/2e74eccd742ee8e8439fd7f6f9b88ac5dd439c19/R/mfl_scoring.R#L41-L43

While that currently works, some changes in `unnest_wider()` are going to make unnesting a mixture of lists and tibbles like that fail.

I think it would be a lot cleaner and safer if you go ahead and convert all of the list elements to tibbles using different variations of `bind_rows()`, depending on the depth. Then `unnest_wider()` will work fine.

Concretely, if you were to run this code, then it would fail with the changes I'm going to make to `unnest_wider()`.

```r
library(ffscrapr)

dlf_conn <- ff_connect("mfl", 37920, season = 2020)
dlf_league <- ff_league(dlf_conn)
```

The failure happens in `ff_league()`. Right after this `case_when()` has run, you end up with the following object:
https://github.com/ffverse/ffscrapr/blob/2e74eccd742ee8e8439fd7f6f9b88ac5dd439c19/R/mfl_scoring.R#L37-L40

``` r
library(tibble)

tmp <- structure(list(positions = c("TE", "QB|RB|WR|TE|PK", "WR"), rule = list(
  list(points = "*1.5", range = "0-99", event = "CC"), list(
    list(points = "*4", range = "1-10", event = "#P"), list(
      points = "*0.04", range = "1-999", event = "PY"), 
    list(points = "*-2", range = "1-10", event = "IN"), list(
      points = "*1", range = "1-10", event = "P2"), list(
        points = "*6", range = "1-10", event = "#R"), list(
          points = "*0.1", range = "1-999", event = "RY"), 
    list(points = "*2", range = "1-10", event = "R2"), list(
      points = "*6", range = "1-10", event = "#C"), list(
        points = "*0.1", range = "1-999", event = "CY"), 
    list(points = "*2", range = "1-10", event = "C2"), list(
      points = "*-1", range = "0-10", event = "FU"), list(
        points = "*-1", range = "0-10", event = "FL"), list(
          points = "1/1", range = "1-50", event = "1R"), list(
            points = "1/1", range = "1-50", event = "1C")), list(
              points = "*0.5", range = "0-99", event = "CC")), vec_depth = c(3, 
                                                                             4, 3)), class = c("tbl_df", "tbl", "data.frame"), row.names = c(NA, 
                                                                                                                                             -3L))
tmp
#> # A tibble: 3 × 3
#>   positions      rule             vec_depth
#>   <chr>          <list>               <dbl>
#> 1 TE             <named list [3]>         3
#> 2 QB|RB|WR|TE|PK <list [14]>              4
#> 3 WR             <named list [3]>         3
```

Here is what you currently do with that, vs what I am suggesting with this PR

``` r
# Current behavior returns a mix of lists and tibbles to unnest
tmp %>% 
  dplyr::mutate(
    rule = dplyr::case_when(
      .data$vec_depth == 4 ~ purrr::map(.data$rule, dplyr::bind_rows),
      TRUE ~ .data$rule
    )
  )
#> # A tibble: 3 × 3
#>   positions      rule              vec_depth
#>   <chr>          <list>                <dbl>
#> 1 TE             <named list [3]>          3
#> 2 QB|RB|WR|TE|PK <tibble [14 × 3]>         4
#> 3 WR             <named list [3]>          3


# Little helper to avoid calling `!!!` directly in a `dplyr::mutate()`
list_bind_rows <- function(x) {
  dplyr::bind_rows(!!!x)
}

# Proposal: Always return a tibble for each element, and don't
# rely on bind_rows()'s list flattening abilities
tmp %>% 
  dplyr::mutate(
    rule = dplyr::case_when(
      .data$vec_depth == 3 ~ purrr::map(.data$rule, dplyr::bind_rows),
      .data$vec_depth == 4 ~ purrr::map(.data$rule, list_bind_rows)
    )
  )
#> # A tibble: 3 × 3
#>   positions      rule              vec_depth
#>   <chr>          <list>                <dbl>
#> 1 TE             <tibble [1 × 3]>          3
#> 2 QB|RB|WR|TE|PK <tibble [14 × 3]>         4
#> 3 WR             <tibble [1 × 3]>          3
```