### PR TITLE
Refactor tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Depends:
 Imports:
     cachem (>= 1.0.0),
     checkmate (>= 2.0.0),
+    cli,
     dplyr (>= 1.0.0),
     glue (>= 1.3.0),
     httr (>= 1.4.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ffscrapr
 Title: API Client for Fantasy Football League Platforms
-Version: 1.4.7.11
+Version: 1.4.7.12
 Authors@R: 
     c(person(given = "Tan",
              family = "Ho",

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - `sleeper_connect()` now warns if you use a non-character league_id parameter - Sleeper league IDs are too long (18 characters) and longdouble support is inconsistent from OS to OS. (1.4.7.09)
 - `ff_standings.mfl_conn()` changed to adapt to MFL API changes as documented in [2022 API release notes ](https://api.myfantasyleague.com/2022/site_news?ARTICLE=1658765676), resolves #366. (1.4.7.10)
 - `ff_starters.sleeper_conn()` bugfixed for API change (last-scored-leg -> leg) (1.4.7.11)
+- `ff_scoring()` fixed for dev purrr issues. (1.4.7.12)
 
 ---
 

--- a/R/espn_schedule.R
+++ b/R/espn_schedule.R
@@ -58,10 +58,10 @@ ff_schedule.espn_conn <- function(conn, ...) {
     dplyr::bind_rows(scores, scores2) %>%
     dplyr::arrange(.data$week, .data$home_id, .data$away_id) %>%
     dplyr::rename(
-      "franchise_id" = .data$home_id,
-      "opponent_id" = .data$away_id,
-      "franchise_score" = .data$home_points,
-      "opponent_score" = .data$away_points
+      "franchise_id" = "home_id",
+      "opponent_id" = "away_id",
+      "franchise_score" = "home_points",
+      "opponent_score" = "away_points"
     ) %>%
     dplyr::mutate(
       result = dplyr::case_when(
@@ -73,12 +73,12 @@ ff_schedule.espn_conn <- function(conn, ...) {
       )
     ) %>%
     dplyr::select(
-      .data$week,
-      .data$franchise_id,
-      .data$franchise_score,
-      .data$result,
-      .data$opponent_id,
-      .data$opponent_score
+      "week",
+      "franchise_id",
+      "franchise_score",
+      "result",
+      "opponent_id",
+      "opponent_score"
     ) %>%
     dplyr::filter(!is.na(.data$franchise_id))
   return(schedule)

--- a/R/espn_scoringhistory.R
+++ b/R/espn_scoringhistory.R
@@ -50,8 +50,8 @@ ff_scoringhistory.espn_conn <- function(conn, season = 1999:nflreadr::most_recen
     dplyr::ungroup() %>%
     tidyr::pivot_wider(
       id_cols = c("season", "week", "gsis_id", "sportradar_id", "espn_id", "player_name", "pos", "team", "points"),
-      names_from = .data$metric,
-      values_from = .data$value,
+      names_from = "metric",
+      values_from = "value",
       values_fill = 0,
       values_fn = max
     )

--- a/R/espn_starters.R
+++ b/R/espn_starters.R
@@ -100,7 +100,7 @@ ff_starters.espn_conn <- function(conn, weeks = 1:17, ...) {
     purrr::set_names("x") %>%
     tidyr::hoist(1, "week" = "matchupPeriodId", "home", "away") %>%
     dplyr::filter(.data$week == .env$week) %>%
-    tidyr::pivot_longer(c(.data$home, .data$away), names_to = NULL, values_to = "team") %>%
+    tidyr::pivot_longer(c("home", "away"), names_to = NULL, values_to = "team") %>%
     tidyr::hoist("team", "starting_lineup" = "rosterForCurrentScoringPeriod", "franchise_id" = "teamId") %>%
     dplyr::select(-"team", -"x") %>%
     tidyr::hoist("starting_lineup", "franchise_score" = "appliedStatTotal", "entries") %>%

--- a/R/espn_transactions.R
+++ b/R/espn_transactions.R
@@ -94,8 +94,8 @@ ff_transactions.espn_conn <- function(conn, limit = 1000, ...) {
     trade_transactions <- all_transactions %>%
       dplyr::filter(.data$type == "TRADE") %>%
       dplyr::select(
-        trade_partner = .data$franchise_id,
-        franchise_id = .data$trade_partner,
+        trade_partner = "franchise_id",
+        franchise_id = "trade_partner",
         "player_id",
         "timestamp"
       ) %>%

--- a/R/flea_scoringhistory.R
+++ b/R/flea_scoringhistory.R
@@ -49,8 +49,8 @@ ff_scoringhistory.flea_conn <- function(conn, season = 1999:nflreadr::most_recen
     tidyr::pivot_wider(
       id_cols = c("season", "week", "gsis_id", "sportradar_id","fleaflicker_id",
                   "player_name", "pos", "team", "points"),
-      names_from = .data$metric,
-      values_from = .data$value,
+      names_from = "metric",
+      values_from = "value",
       values_fill = 0,
       values_fn = max
     )

--- a/R/flea_transactions.R
+++ b/R/flea_transactions.R
@@ -174,7 +174,7 @@ ff_transactions.flea_conn <- function(conn, franchise_id = NULL, ...) {
       "pos" = "position",
       "team" = "proTeamAbbreviation"
     ) %>%
-    dplyr::select(-.data$player, -.data$franchise)
+    dplyr::select(-"player", -"franchise")
 
   if ("waiverResolutionTeams" %in% names(claims)) {
     claims <- claims %>%

--- a/R/flea_userleagues.R
+++ b/R/flea_userleagues.R
@@ -47,8 +47,8 @@ fleaflicker_userleagues <- function(user_email, season = NULL) {
     tibble::tibble() %>%
     tidyr::unnest_wider(1) %>%
     dplyr::rename(
-      league_name = .data$name,
-      league_id = .data$id
+      league_name = "name",
+      league_id = "id"
     ) %>%
     tidyr::hoist("ownedTeam", "franchise_id" = "id", "franchise_name" = "name") %>%
     dplyr::select(-"ownedTeam")

--- a/R/mfl_draft.R
+++ b/R/mfl_draft.R
@@ -115,7 +115,7 @@ ff_draft.mfl_conn <- function(conn, custom_players = deprecated(), ...) {
       overall = dplyr::row_number()
     ) %>%
     dplyr::rename(
-      "franchise_id" = .data$franchise,
-      "player_id" = .data$player
+      "franchise_id" = "franchise",
+      "player_id" = "player"
     )
 }

--- a/R/mfl_franchises.R
+++ b/R/mfl_franchises.R
@@ -24,8 +24,8 @@ ff_franchises.mfl_conn <- function(conn) {
     tibble::tibble() %>%
     tidyr::unnest_wider(1) %>%
     dplyr::rename(
-      "franchise_name" = .data$name,
-      "franchise_id" = .data$id
+      "franchise_name" = "name",
+      "franchise_id" = "id"
     ) %>%
     dplyr::select("franchise_id", "franchise_name", dplyr::everything())
 
@@ -34,8 +34,8 @@ ff_franchises.mfl_conn <- function(conn) {
       tibble::tibble() %>%
       tidyr::unnest_wider(1) %>%
       dplyr::rename(
-        "division_name" = .data$name,
-        "division_id" = .data$id
+        "division_name" = "name",
+        "division_id" = "id"
       )
 
     franchises <- franchises %>%

--- a/R/mfl_rosters.R
+++ b/R/mfl_rosters.R
@@ -35,8 +35,8 @@ ff_rosters.mfl_conn <- function(conn, custom_players = deprecated(), week = NULL
     dplyr::mutate("player" = purrr::map(.data$player, dplyr::bind_rows)) %>%
     tidyr::unnest("player") %>%
     dplyr::rename(
-      "player_id" = .data$id,
-      "roster_status" = .data$status
+      "player_id" = "id",
+      "roster_status" = "status"
     ) %>%
     dplyr::select("franchise_id", "player_id", dplyr::everything())
 

--- a/R/mfl_scoring.R
+++ b/R/mfl_scoring.R
@@ -101,9 +101,10 @@ mfl_allrules <- function(conn) {
     purrr::pluck("content", "allRules", "rule") %>%
     tibble::tibble() %>%
     tidyr::unnest_wider(1) %>%
-    purrr::map_depth(-2, unname, 1, .ragged = TRUE) %>%
-    purrr::map_depth(2, `[[`, 1) %>%
-    dplyr::as_tibble() %>%
+    dplyr::mutate_if(is.list,
+                     ~replace(.x, lengths(.x) == 0, NA_character_) %>%
+                       unlist() %>%
+                       unname()) %>%
     dplyr::mutate_all(as.character) %>%
     dplyr::select(
       "abbrev" = "abbreviation",

--- a/R/mfl_scoring.R
+++ b/R/mfl_scoring.R
@@ -40,7 +40,7 @@ ff_scoring.mfl_conn <- function(conn) {
       ),
       rule = purrr::map(.data$rule, dplyr::bind_rows)
     ) %>%
-    dplyr::select(-.data$vec_depth) %>%
+    dplyr::select(-"vec_depth") %>%
     tidyr::unnest_wider("rule") %>%
     tidyr::unnest(c("points", "event", "range")) %>%
     tidyr::separate_rows("positions", sep = "\\|") %>%
@@ -53,7 +53,7 @@ ff_scoring.mfl_conn <- function(conn) {
       points = as.double(.data$points)
     ) %>%
     dplyr::select(
-      "pos" = .data$positions,
+      "pos" = "positions",
       "points",
       "range",
       "event",

--- a/R/mfl_scoring.R
+++ b/R/mfl_scoring.R
@@ -31,21 +31,15 @@ ff_scoring.mfl_conn <- function(conn) {
     df <- df %>% tibble::as_tibble()
   }
 
-  extract_rule <- function(rule) {
-    depth <- purrr::vec_depth(rule)
-    if (depth == 3) {
-      purrr::map_depth(rule, 2, `[[`, 1)
-    } else if (depth == 4) {
-      purrr::map_depth(rule, -2, `[[`, 1)
-    }
-  }
 
   df <- df %>%
     dplyr::mutate(
-      rule = purrr::map(.data$rule, extract_rule),
+      # convert each nested list of rules to tibble by bind_rows
+      # so that it can be unnested nicely
+      # see ffscrapr#344 for history
       rule = purrr::map(.data$rule, dplyr::bind_rows)
     ) %>%
-    tidyr::unnest_wider("rule") %>%
+    tidyr::unnest("rule") %>%
     tidyr::unnest(c("points", "event", "range")) %>%
     tidyr::separate_rows("positions", sep = "\\|") %>%
     dplyr::left_join(mfl_allrules(conn), by = c("event" = "abbrev")) %>%

--- a/R/mfl_scoringhistory.R
+++ b/R/mfl_scoringhistory.R
@@ -65,8 +65,8 @@ ff_scoringhistory.mfl_conn <- function(conn, season = 1999:nflreadr::most_recent
     tidyr::pivot_wider(
       id_cols = c("season", "week", "gsis_id", "sportradar_id",
                   "mfl_id", "player_name", "pos", "team", "points"),
-      names_from = .data$metric,
-      values_from = .data$value,
+      names_from = "metric",
+      values_from = "value",
       values_fill = 0,
       values_fn = max
     )

--- a/R/mfl_starters.R
+++ b/R/mfl_starters.R
@@ -35,7 +35,7 @@ ff_starters.mfl_conn <- function(conn, week = 1:17, season = NULL, ...) {
     week = week
   ) %>%
     dplyr::mutate(starters = purrr::map2(week, season, .mfl_weeklystarters, conn)) %>%
-    tidyr::unnest(.data$starters) %>%
+    tidyr::unnest("starters") %>%
     dplyr::mutate(
       player_score = as.numeric(.data$player_score),
       should_start = as.numeric(.data$should_start)

--- a/R/mfl_transactions.R
+++ b/R/mfl_transactions.R
@@ -113,19 +113,19 @@ ff_transactions.mfl_conn <- function(conn, transaction_type = "*", ...) {
 
   df <- parsed_trades %>%
     dplyr::select(
-      .data$timestamp,
-      .data$type,
-      "franchise" = .data$franchise2,
-      "franchise2" = .data$franchise,
-      "franchise1_gave_up" = .data$franchise2_gave_up,
-      "franchise2_gave_up" = .data$franchise1_gave_up,
-      .data$comments
+      "timestamp",
+      "type",
+      "franchise" = "franchise2",
+      "franchise2" = "franchise",
+      "franchise1_gave_up" = "franchise2_gave_up",
+      "franchise2_gave_up" = "franchise1_gave_up",
+      "comments"
     ) %>%
     dplyr::bind_rows(parsed_trades) %>%
     dplyr::rename(
-      "trade_partner" = .data$franchise2,
-      "traded_for" = .data$franchise2_gave_up,
-      "traded_away" = .data$franchise1_gave_up
+      "trade_partner" = "franchise2",
+      "traded_for" = "franchise2_gave_up",
+      "traded_away" = "franchise1_gave_up"
     ) %>%
     dplyr::arrange(dplyr::desc(.data$timestamp)) %>%
     tidyr::pivot_longer(c("traded_away", "traded_for"),
@@ -160,12 +160,12 @@ ff_transactions.mfl_conn <- function(conn, transaction_type = "*", ...) {
 
   parsed_fa %>%
     dplyr::select(
-      .data$timestamp,
-      .data$type,
-      .data$franchise,
-      .data$type_desc,
-      .data$player_id,
-      .data$comments
+      "timestamp",
+      "type",
+      "franchise",
+      "type_desc",
+      "player_id",
+      "comments"
     ) %>%
     dplyr::arrange(dplyr::desc(.data$timestamp))
 }
@@ -192,12 +192,12 @@ ff_transactions.mfl_conn <- function(conn, transaction_type = "*", ...) {
 
   parsed_ir %>%
     dplyr::select(
-      .data$timestamp,
-      .data$type,
-      .data$franchise,
-      .data$type_desc,
-      .data$player_id,
-      .data$comments
+      "timestamp",
+      "type",
+      "franchise",
+      "type_desc",
+      "player_id",
+      "comments"
     ) %>%
     dplyr::arrange(dplyr::desc(.data$timestamp))
 }
@@ -224,12 +224,12 @@ ff_transactions.mfl_conn <- function(conn, transaction_type = "*", ...) {
 
   parsed_ts %>%
     dplyr::select(
-      .data$timestamp,
-      .data$type,
-      .data$franchise,
-      .data$type_desc,
-      .data$player_id,
-      .data$comments
+      "timestamp",
+      "type",
+      "franchise",
+      "type_desc",
+      "player_id",
+      "comments"
     ) %>%
     dplyr::arrange(dplyr::desc(.data$timestamp))
 }
@@ -263,13 +263,13 @@ ff_transactions.mfl_conn <- function(conn, transaction_type = "*", ...) {
 
   parsed_bbid_drops %>%
     dplyr::select(
-      .data$timestamp,
-      .data$type,
-      .data$franchise,
-      .data$type_desc,
-      .data$player_id,
-      .data$bbid_spent,
-      .data$comments
+      "timestamp",
+      "type",
+      "franchise",
+      "type_desc",
+      "player_id",
+      "bbid_spent",
+      "comments"
     ) %>%
     dplyr::arrange(dplyr::desc(.data$timestamp))
 }

--- a/R/mfl_userleagues.R
+++ b/R/mfl_userleagues.R
@@ -26,9 +26,9 @@ ff_userleagues.mfl_conn <- function(conn, season = NULL, ...) {
     df <- df_leagues %>%
       tibble::as_tibble() %>%
       dplyr::select("league_id",
-        "league_name" = .data$name,
+        "league_name" = "name",
         "franchise_id", "franchise_name",
-        "league_url" = .data$url
+        "league_url" = "url"
       )
   }
 

--- a/R/sleeper_draft.R
+++ b/R/sleeper_draft.R
@@ -27,7 +27,7 @@ ff_draft.sleeper_conn <- function(conn, ...) {
     purrr::pluck("content") %>%
     purrr::map_dfr(`[`, c("season", "draft_id", "league_id", "status", "type")) %>%
     dplyr::mutate(picks = purrr::map(.data$draft_id, .sleeper_currentdraft)) %>%
-    tidyr::unnest(.data$picks) %>%
+    tidyr::unnest("picks") %>%
     dplyr::left_join(franchise_endpoint, by = "franchise_id") %>%
     dplyr::left_join(players_endpoint, by = "player_id") %>%
     dplyr::select(dplyr::any_of(c(

--- a/R/sleeper_draftpicks.R
+++ b/R/sleeper_draftpicks.R
@@ -53,7 +53,7 @@ ff_draftpicks.sleeper_conn <- function(conn, ...) {
     purrr::map_dfr(`[`, c("draft_id", "season", "status")) %>%
     dplyr::filter(.data$status != "complete") %>%
     dplyr::mutate(picks = purrr::map(.data$draft_id, .sleeper_currentdraft)) %>%
-    tidyr::unnest(.data$picks) %>%
+    tidyr::unnest("picks") %>%
     dplyr::select(dplyr::any_of(c(
       "season", "round", "pick", "franchise_id"
     )))

--- a/R/sleeper_franchises.R
+++ b/R/sleeper_franchises.R
@@ -38,7 +38,7 @@ ff_franchises.sleeper_conn <- function(conn) {
   df_ownerlist <- rosters_response %>%
     dplyr::left_join(users_response, by = c("owner_id" = "user_id")) %>%
     dplyr::select(
-      "franchise_id" = .data$roster_id,
+      "franchise_id" = "roster_id",
       dplyr::any_of(c("franchise_name", "user_name", "user_id" = "owner_id", "co_owners"))
     )
 

--- a/R/sleeper_players.R
+++ b/R/sleeper_players.R
@@ -28,12 +28,12 @@ sleeper_players <- function() {
     dplyr::select(-dplyr::contains("search"), -dplyr::contains("first_name"), -dplyr::contains("last_name"), -dplyr::contains("metadata")) %>%
     dplyr::select(
       "player_id",
-      "player_name" = .data$full_name,
-      "pos" = .data$position,
-      .data$age,
-      .data$team,
-      .data$status,
-      .data$years_exp,
+      "player_name" = "full_name",
+      "pos" = "position",
+      "age",
+      "team",
+      "status",
+      "years_exp",
       dplyr::starts_with("draft_"),
       dplyr::ends_with("_id"),
       dplyr::everything()

--- a/R/sleeper_scoringhistory.R
+++ b/R/sleeper_scoringhistory.R
@@ -47,8 +47,8 @@ ff_scoringhistory.sleeper_conn <- function(conn, season = 1999:nflreadr::most_re
     dplyr::ungroup() %>%
     tidyr::pivot_wider(
       id_cols = c("season", "week", "gsis_id", "sportradar_id", "sleeper_id", "player_name", "pos", "team", "points"),
-      names_from = .data$metric,
-      values_from = .data$value,
+      names_from = "metric",
+      values_from = "value",
       values_fill = 0,
       values_fn = max
     )

--- a/R/sleeper_starters.R
+++ b/R/sleeper_starters.R
@@ -35,7 +35,7 @@ ff_starters.sleeper_conn <- function(conn, week = 1:17, ...) {
     week = week
   ) %>%
     dplyr::mutate(starters = purrr::map(week, .sleeper_weeklystarters, conn)) %>%
-    tidyr::unnest(.data$starters) %>%
+    tidyr::unnest("starters") %>%
     dplyr::left_join(
       franchises_endpoint,
       by = "franchise_id"

--- a/R/sleeper_transactions.R
+++ b/R/sleeper_transactions.R
@@ -272,7 +272,7 @@ ff_transactions.sleeper_conn <- function(conn, week = 1:17, ...) {
             "round",
             .data$round,
             "pick_from_franchise",
-            .data$roster_id,
+            roster_id,
             sep = "_"
           )) %>%
           dplyr::select(

--- a/R/sleeper_transactions.R
+++ b/R/sleeper_transactions.R
@@ -108,7 +108,7 @@ ff_transactions.sleeper_conn <- function(conn, week = 1:17, ...) {
       added = purrr::map(.data$added, ~ replace(.x, is.null(.x), NA_character_)),
       dropped = purrr::map(.data$dropped, names),
       dropped = purrr::map(.data$dropped, ~ replace(.x, is.null(.x), NA_character_)),
-      franchise_id = purrr::map_chr(.data$franchise_id, unlist),
+      franchise_id = purrr::map_chr(.data$franchise_id, ~as.character(unlist(.x))),
       timestamp = .data$timestamp / 1000,
       timestamp = .as_datetime(.data$timestamp)
     ) %>%
@@ -165,7 +165,7 @@ ff_transactions.sleeper_conn <- function(conn, week = 1:17, ...) {
       added = purrr::map(.data$added, ~ replace(.x, is.null(.x), NA_character_)),
       dropped = purrr::map(.data$dropped, names),
       dropped = purrr::map(.data$dropped, ~ replace(.x, is.null(.x), NA_character_)),
-      franchise_id = purrr::map_chr(.data$franchise_id, unlist),
+      franchise_id = purrr::map_chr(.data$franchise_id, ~as.character(unlist(.x))),
       timestamp = .data$timestamp / 1000,
       timestamp = .as_datetime(.data$timestamp),
       comment = purrr::map_chr(.data$metadata, `[[`, "notes")

--- a/R/sleeper_userleagues.R
+++ b/R/sleeper_userleagues.R
@@ -33,7 +33,7 @@ ff_userleagues.sleeper_conn <- function(conn = NULL, user_name = NULL, season = 
   df_leagues <- sleeper_getendpoint(glue::glue("user/{user_id}/leagues/nfl/{season}")) %>%
     purrr::pluck("content") %>%
     purrr::map_dfr(`[`, c("name", "league_id")) %>%
-    dplyr::rename(league_name = .data$name) %>%
+    dplyr::rename(league_name = "name") %>%
     dplyr::mutate(
       league_id = as.character(league_id),
       franchise_name = purrr::map_chr(.data$league_id, .sleeper_userteams, user_id),

--- a/R/template_scoringhistory.R
+++ b/R/template_scoringhistory.R
@@ -64,8 +64,8 @@ ff_scoringhistory.template_conn <- function(conn, season = 1999:nflreadr::most_r
     tidyr::pivot_wider(
       id_cols = c("season", "week", "gsis_id", "sportradar_id",
                   "mfl_id", "player_name", "pos", "team", "points"),
-      names_from = .data$metric,
-      values_from = .data$value,
+      names_from = "metric",
+      values_from = "value",
       values_fill = 0,
       values_fn = max
     )

--- a/ffscrapr.Rproj
+++ b/ffscrapr.Rproj
@@ -17,5 +17,8 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace
+
+UseNativePipeOperator: No

--- a/tests/testthat/helper-mocking.R
+++ b/tests/testthat/helper-mocking.R
@@ -1,12 +1,30 @@
 library(checkmate)
 
-# Download test files if running mocked tests
+## Testing scenarios
+#
+# 1. If GitHub is offline, skip all tests.
+#
+# 2. If MOCK_BYPASS environment variable is set to TRUE, run tests without mocking.
+#
+# 3. If GitHub is online and MOCK_BYPASS environment variable not set to TRUE,
+# attempt to download mock files from GitHub.
+#
+# 3a. If there are any failures with downloading mock files, skip all tests.
+# 3b. If everything works, run the tests against mock files.
+
+# Goal of testing with mock is to test data cleaning/transformation dependencies
+# as they change on CRAN (and hold API responses constant).
+
 needs_mocking <- function() {
   !identical(Sys.getenv("MOCK_BYPASS"), "true")
 }
 
-if (needs_mocking()) {
-  cache_dir <- tools::R_user_dir("ffscrapr")
+github_online <- function(){
+  !identical(curl::nslookup("github.com"),"")
+}
+
+if (needs_mocking() & github_online()) {
+  cache_dir <- rappdirs::user_cache_dir("ffscrapr")
   if (!file.exists(cache_dir)) {
     dir.create(cache_dir, showWarnings = FALSE, recursive = TRUE)
   }
@@ -15,6 +33,7 @@ if (needs_mocking()) {
 
   # Cache for 24 hours
   if (!file.exists(cache_path) || difftime(Sys.time(), file.mtime(cache_path), units = "days") > 1) {
+
     path <- tempfile()
     download.file("https://github.com/ffverse/ffscrapr-tests/archive/1.4.7.zip", path)
     unzip(path, exdir = cache_dir)
@@ -25,9 +44,12 @@ if (needs_mocking()) {
 }
 
 local_mock_api <- function(envir = parent.frame()) {
-  if (!needs_mocking()) {
-    return()
-  }
+  if (!needs_mocking()) return()
+
+  if (!github_online()) testthat::skip("GitHub offline!")
+
+  cache_path <- file.path(rappdirs::user_cache_dir("ffscrapr"), "ffscrapr-tests-1.4.7")
+  if(!file.exists(cache_path)) testthat::skip("Could not find cache files!")
 
   httptest::use_mock_api()
   withr::defer(httptest::stop_mocking(), envir = envir)

--- a/tests/testthat/helper-mocking.R
+++ b/tests/testthat/helper-mocking.R
@@ -11,12 +11,12 @@ if (needs_mocking()) {
     dir.create(cache_dir, showWarnings = FALSE, recursive = TRUE)
   }
 
-  cache_path <- file.path(cache_dir, "ffscrapr-tests-main")
+  cache_path <- file.path(cache_dir, "ffscrapr-tests-1.4.7")
 
   # Cache for 24 hours
   if (!file.exists(cache_path) || difftime(Sys.time(), file.mtime(cache_path), units = "days") > 1) {
     path <- tempfile()
-    download.file("https://github.com/ffverse/ffscrapr-tests/archive/main.zip", path)
+    download.file("https://github.com/ffverse/ffscrapr-tests/archive/1.4.7.zip", path)
     unzip(path, exdir = cache_dir)
     unlink(path)
   }

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -1,11 +1,11 @@
-with_mock_api({
-  test_that("Cache clearing works", {
-    conn <- mfl_connect(2020, 54040)
-    x <- mfl_players(conn)
-    expect(memoise::has_cache(mfl_players)(conn), "Function wasn't memoised!")
+test_that("Cache clearing works", {
+  local_mock_api()
 
-    .ff_clear_cache()
+  conn <- mfl_connect(2020, 54040)
+  x <- mfl_players(conn)
+  expect(memoise::has_cache(mfl_players)(conn), "Function wasn't memoised!")
 
-    expect(!memoise::has_cache(mfl_players)(conn), "Cache has been cleared!")
-  })
+  .ff_clear_cache()
+
+  expect(!memoise::has_cache(mfl_players)(conn), "Cache has been cleared!")
 })

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -1,7 +1,5 @@
 with_mock_api({
   test_that("Cache clearing works", {
-    skippy()
-
     conn <- mfl_connect(2020, 54040)
     x <- mfl_players(conn)
     expect(memoise::has_cache(mfl_players)(conn), "Function wasn't memoised!")

--- a/tests/testthat/test-ff_connect.R
+++ b/tests/testthat/test-ff_connect.R
@@ -1,46 +1,48 @@
-with_mock_api({
-  test_that("ff_connect returns an S3 platform_conn obj for each platform currently programmed", {
-    ssb <- ff_connect("mfl", 54040, user_agent = "ffscrapr_test")
-    jml <- ff_connect("sleeper", "527362181635997696")
-    solar <- ff_connect(
-      platform = "sleeper",
-      user_name = "solarpool"
-    )
-    joe <- ff_connect("flea", 312861)
+test_that("ff_connect returns an S3 platform_conn obj for each platform currently programmed", {
+  local_mock_api()
 
-    dlp <- ff_connect("espn", 1178049)
+  ssb <- ff_connect("mfl", 54040, user_agent = "ffscrapr_test")
+  jml <- ff_connect("sleeper", "527362181635997696")
+  solar <- ff_connect(
+    platform = "sleeper",
+    user_name = "solarpool"
+  )
+  joe <- ff_connect("flea", 312861)
 
-    expect_s3_class(ssb, "mfl_conn")
-    expect_s3_class(jml, "sleeper_conn")
-    expect_s3_class(solar, "sleeper_conn")
-    expect_s3_class(joe, "flea_conn")
-    expect_s3_class(dlp, "espn_conn")
-  })
+  dlp <- ff_connect("espn", 1178049)
 
-  test_that("Does mfl-logincookie return a request-like object?", {
-    request <- .mfl_logincookie(
-      user_name = "dynastyprocesstest",
-      password = "test1234",
-      season = "2020"
-    )
-    expect_s3_class(request, "request")
-  })
+  expect_s3_class(ssb, "mfl_conn")
+  expect_s3_class(jml, "sleeper_conn")
+  expect_s3_class(solar, "sleeper_conn")
+  expect_s3_class(joe, "flea_conn")
+  expect_s3_class(dlp, "espn_conn")
+})
 
-  test_that("Does mfl_connect returns an mfl-connection object?", {
-    conn <- mfl_connect(
-      season = 2020,
-      league_id = 54040,
-      user_name = "dynastyprocesstest",
-      password = "test1234",
-      rate_limit = FALSE
-    )
+test_that("Does mfl-logincookie return a request-like object?", {
+  local_mock_api()
+  request <- .mfl_logincookie(
+    user_name = "dynastyprocesstest",
+    password = "test1234",
+    season = "2020"
+  )
+  expect_s3_class(request, "request")
+})
 
-    expect_s3_class(conn, "mfl_conn")
-    expect_error(mfl_connect(2020, 54040, rate_limit = "bork"))
-    expect_message(mfl_connect(2020, 54040, user_name = "dynastyprocesstest"))
-    expect_message(mfl_connect(2020, 54040, password = "test1234"))
-    expect_output(print(conn), "*MFL conn*")
-  })
+test_that("Does mfl_connect returns an mfl-connection object?", {
+  local_mock_api()
+  conn <- mfl_connect(
+    season = 2020,
+    league_id = 54040,
+    user_name = "dynastyprocesstest",
+    password = "test1234",
+    rate_limit = FALSE
+  )
+
+  expect_s3_class(conn, "mfl_conn")
+  expect_error(mfl_connect(2020, 54040, rate_limit = "bork"))
+  expect_message(mfl_connect(2020, 54040, user_name = "dynastyprocesstest"))
+  expect_message(mfl_connect(2020, 54040, password = "test1234"))
+  expect_output(print(conn), "*MFL conn*")
 })
 
 test_that("sleeper_connect edge cases are handled", {

--- a/tests/testthat/test-ff_connect.R
+++ b/tests/testthat/test-ff_connect.R
@@ -1,6 +1,5 @@
 with_mock_api({
   test_that("ff_connect returns an S3 platform_conn obj for each platform currently programmed", {
-    skippy()
     ssb <- ff_connect("mfl", 54040, user_agent = "ffscrapr_test")
     jml <- ff_connect("sleeper", "527362181635997696")
     solar <- ff_connect(
@@ -19,7 +18,6 @@ with_mock_api({
   })
 
   test_that("Does mfl-logincookie return a request-like object?", {
-    skippy()
     request <- .mfl_logincookie(
       user_name = "dynastyprocesstest",
       password = "test1234",
@@ -29,7 +27,6 @@ with_mock_api({
   })
 
   test_that("Does mfl_connect returns an mfl-connection object?", {
-    skippy()
     conn <- mfl_connect(
       season = 2020,
       league_id = 54040,
@@ -47,13 +44,11 @@ with_mock_api({
 })
 
 test_that("sleeper_connect edge cases are handled", {
-  skippy()
   expect_error(sleeper_connect(user_agent = c("pie", "cake")), regexp = "character vector of length one")
   expect_error(sleeper_connect(user_agent = "ffscraprtest", rate_limit = 1), regexp = "rate_limit should be logical")
 })
 
 test_that("ESPN connect cookie authentication works", {
-  skippy()
   dlp <- espn_connect(season = 2020, league_id = 1178049, swid = "{1E6BB139}", espn_s2 = "AECt%2FIDwd5kt")
 
   expect_character(dlp$cookies$options$cookie,

--- a/tests/testthat/test-ff_draft.R
+++ b/tests/testthat/test-ff_draft.R
@@ -1,33 +1,32 @@
-with_mock_api({
-  test_that("ff_draft returns a tibble for each platform currently programmed", {
-    sfb_conn <- ff_connect("mfl", 65443, season = 2020)
-    sfb_draftresults <- ff_draft(sfb_conn)
+test_that("ff_draft returns a tibble for each platform currently programmed", {
+  local_mock_api()
+  sfb_conn <- ff_connect("mfl", 65443, season = 2020)
+  sfb_draftresults <- ff_draft(sfb_conn)
 
-    expect_tibble(sfb_draftresults, min.rows = 100)
+  expect_tibble(sfb_draftresults, min.rows = 100)
 
-    ssb_conn <- ff_connect("mfl", 54040, season = 2020)
-    ssb_draftresults <- ff_draft(ssb_conn)
+  ssb_conn <- ff_connect("mfl", 54040, season = 2020)
+  ssb_draftresults <- ff_draft(ssb_conn)
 
-    expect_tibble(ssb_draftresults, min.rows = 40)
+  expect_tibble(ssb_draftresults, min.rows = 40)
 
-    jml_conn <- ff_connect(platform = "sleeper", league_id = "522458773317046272", season = 2020)
-    jml_draftresults <- ff_draft(jml_conn)
+  jml_conn <- ff_connect(platform = "sleeper", league_id = "522458773317046272", season = 2020)
+  jml_draftresults <- ff_draft(jml_conn)
 
-    expect_tibble(jml_draftresults, min.rows = 40)
+  expect_tibble(jml_draftresults, min.rows = 40)
 
-    auction_conn <- ff_connect(platform = "sleeper", league_id = "695482984576385024", season = 2021)
-    auction_draftresults <- ff_draft(auction_conn)
+  auction_conn <- ff_connect(platform = "sleeper", league_id = "695482984576385024", season = 2021)
+  auction_draftresults <- ff_draft(auction_conn)
 
-    expect_tibble(auction_draftresults, min.rows = 250)
+  expect_tibble(auction_draftresults, min.rows = 250)
 
-    joe_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
-    joe_draftresults <- ff_draft(joe_conn)
+  joe_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
+  joe_draftresults <- ff_draft(joe_conn)
 
-    expect_tibble(joe_draftresults)
+  expect_tibble(joe_draftresults)
 
-    tony <- espn_connect(season = 2020, league_id = 899513)
-    tony_draftresults <- ff_draft(tony)
+  tony <- espn_connect(season = 2020, league_id = 899513)
+  tony_draftresults <- ff_draft(tony)
 
-    expect_tibble(tony_draftresults, min.rows = 200)
-  })
+  expect_tibble(tony_draftresults, min.rows = 200)
 })

--- a/tests/testthat/test-ff_draft.R
+++ b/tests/testthat/test-ff_draft.R
@@ -1,7 +1,5 @@
 with_mock_api({
   test_that("ff_draft returns a tibble for each platform currently programmed", {
-    skippy()
-
     sfb_conn <- ff_connect("mfl", 65443, season = 2020)
     sfb_draftresults <- ff_draft(sfb_conn)
 

--- a/tests/testthat/test-ff_draftpicks.R
+++ b/tests/testthat/test-ff_draftpicks.R
@@ -1,30 +1,30 @@
-with_mock_api({
-  test_that("ff_draftpicks returns a tibble of draft picks", {
-    ssb <- mfl_connect(2020, 54040)
-    ssb_picks <- ff_draftpicks(ssb)
+test_that("ff_draftpicks returns a tibble of draft picks", {
+  local_mock_api()
 
-    sfb <- mfl_connect(2020, 65443)
-    sfb_picks <- ff_draftpicks(sfb)
+  ssb <- mfl_connect(2020, 54040)
+  ssb_picks <- ff_draftpicks(ssb)
 
-    expect_tibble(ssb_picks, min.rows = 1)
-    expect_tibble(sfb_picks, nrows = 0)
+  sfb <- mfl_connect(2020, 65443)
+  sfb_picks <- ff_draftpicks(sfb)
 
-    jml_conn <- ff_connect("sleeper", "522458773317046272", season = 2020)
-    jml_picks <- ff_draftpicks(jml_conn)
+  expect_tibble(ssb_picks, min.rows = 1)
+  expect_tibble(sfb_picks, nrows = 0)
 
-    dlp <- sleeper_connect(2020, "521379020332068864")
-    dlp_picks <- ff_draftpicks(dlp)
+  jml_conn <- ff_connect("sleeper", "522458773317046272", season = 2020)
+  jml_picks <- ff_draftpicks(jml_conn)
 
-    expect_tibble(jml_picks, min.rows = 144)
-    expect_tibble(dlp_picks, min.rows = 144)
+  dlp <- sleeper_connect(2020, "521379020332068864")
+  dlp_picks <- ff_draftpicks(dlp)
 
-    joe_conn <- fleaflicker_connect(2020, 206154)
-    joe_picks <- ff_draftpicks(joe_conn, franchise_id = 1373475)
+  expect_tibble(jml_picks, min.rows = 144)
+  expect_tibble(dlp_picks, min.rows = 144)
 
-    expect_tibble(joe_picks, min.rows = 1)
+  joe_conn <- fleaflicker_connect(2020, 206154)
+  joe_picks <- ff_draftpicks(joe_conn, franchise_id = 1373475)
 
-    dlp <- ff_connect("espn", 1178049)
+  expect_tibble(joe_picks, min.rows = 1)
 
-    expect_warning(ff_draftpicks(dlp), regexp = "ESPN does not support draft pick trades")
-  })
+  dlp <- ff_connect("espn", 1178049)
+
+  expect_warning(ff_draftpicks(dlp), regexp = "ESPN does not support draft pick trades")
 })

--- a/tests/testthat/test-ff_draftpicks.R
+++ b/tests/testthat/test-ff_draftpicks.R
@@ -9,15 +9,15 @@ test_that("ff_draftpicks returns a tibble of draft picks", {
 
   expect_tibble(ssb_picks, min.rows = 1)
   expect_tibble(sfb_picks, nrows = 0)
-
-  jml_conn <- ff_connect("sleeper", "522458773317046272", season = 2020)
-  jml_picks <- ff_draftpicks(jml_conn)
-
-  dlp <- sleeper_connect(2020, "521379020332068864")
-  dlp_picks <- ff_draftpicks(dlp)
-
-  expect_tibble(jml_picks, min.rows = 144)
-  expect_tibble(dlp_picks, min.rows = 144)
+#
+#   jml_conn <- ff_connect("sleeper", "522458773317046272", season = 2020)
+#   jml_picks <- ff_draftpicks(jml_conn)
+#
+#   dlp <- sleeper_connect(2020, "521379020332068864")
+#   dlp_picks <- ff_draftpicks(dlp)
+#
+#   expect_tibble(jml_picks, min.rows = 144)
+#   expect_tibble(dlp_picks, min.rows = 144)
 
   joe_conn <- fleaflicker_connect(2020, 206154)
   joe_picks <- ff_draftpicks(joe_conn, franchise_id = 1373475)

--- a/tests/testthat/test-ff_draftpicks.R
+++ b/tests/testthat/test-ff_draftpicks.R
@@ -1,7 +1,5 @@
 with_mock_api({
   test_that("ff_draftpicks returns a tibble of draft picks", {
-    skippy()
-
     ssb <- mfl_connect(2020, 54040)
     ssb_picks <- ff_draftpicks(ssb)
 

--- a/tests/testthat/test-ff_franchises.R
+++ b/tests/testthat/test-ff_franchises.R
@@ -1,7 +1,5 @@
 with_mock_api({
   test_that("ff_franchises returns a tibble of franchises", {
-    skippy()
-
     ssb <- mfl_connect(2019, 54040)
     ssb_franchises <- ff_franchises(ssb)
 

--- a/tests/testthat/test-ff_franchises.R
+++ b/tests/testthat/test-ff_franchises.R
@@ -1,28 +1,28 @@
-with_mock_api({
-  test_that("ff_franchises returns a tibble of franchises", {
-    ssb <- mfl_connect(2019, 54040)
-    ssb_franchises <- ff_franchises(ssb)
+test_that("ff_franchises returns a tibble of franchises", {
+  local_mock_api()
 
-    dlf <- mfl_connect(2020, 37920)
-    dlf_franchises <- ff_franchises(dlf)
+  ssb <- mfl_connect(2019, 54040)
+  ssb_franchises <- ff_franchises(ssb)
 
-    jml <- sleeper_connect(2020, "522458773317046272")
-    jml_franchises <- ff_franchises(jml)
+  dlf <- mfl_connect(2020, 37920)
+  dlf_franchises <- ff_franchises(dlf)
 
-    dlp <- sleeper_connect(2020, "521379020332068864")
-    dlp_franchises <- ff_franchises(dlp)
+  jml <- sleeper_connect(2020, "522458773317046272")
+  jml_franchises <- ff_franchises(jml)
 
-    joe_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
-    joe_franchises <- ff_franchises(joe_conn)
+  dlp <- sleeper_connect(2020, "521379020332068864")
+  dlp_franchises <- ff_franchises(dlp)
 
-    tony <- espn_connect(season = 2020, league_id = 899513)
-    tony_franchises <- ff_franchises(tony)
+  joe_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
+  joe_franchises <- ff_franchises(joe_conn)
 
-    expect_tibble(ssb_franchises, nrows = 14)
-    expect_tibble(dlf_franchises, nrows = 16)
-    expect_tibble(jml_franchises, nrow = 12)
-    expect_tibble(dlp_franchises, nrow = 12)
-    expect_tibble(joe_franchises, nrow = 16)
-    expect_tibble(tony_franchises, nrow = 10)
-  })
+  tony <- espn_connect(season = 2020, league_id = 899513)
+  tony_franchises <- ff_franchises(tony)
+
+  expect_tibble(ssb_franchises, nrows = 14)
+  expect_tibble(dlf_franchises, nrows = 16)
+  expect_tibble(jml_franchises, nrow = 12)
+  expect_tibble(dlp_franchises, nrow = 12)
+  expect_tibble(joe_franchises, nrow = 16)
+  expect_tibble(tony_franchises, nrow = 10)
 })

--- a/tests/testthat/test-ff_league.R
+++ b/tests/testthat/test-ff_league.R
@@ -1,6 +1,5 @@
 with_mock_api({
   test_that("ff_league returns a tibble for each platform currently programmed", {
-    skippy()
     dlf_conn <- ff_connect("mfl", 37920, season = 2020)
     dlf_league <- ff_league(dlf_conn)
 

--- a/tests/testthat/test-ff_league.R
+++ b/tests/testthat/test-ff_league.R
@@ -1,24 +1,24 @@
-with_mock_api({
-  test_that("ff_league returns a tibble for each platform currently programmed", {
-    dlf_conn <- ff_connect("mfl", 37920, season = 2020)
-    dlf_league <- ff_league(dlf_conn)
+test_that("ff_league returns a tibble for each platform currently programmed", {
+  local_mock_api()
 
-    expect_tibble(dlf_league, min.rows = 1)
+  dlf_conn <- ff_connect("mfl", 37920, season = 2020)
+  dlf_league <- ff_league(dlf_conn)
 
-    jml_conn <- ff_connect(platform = "sleeper", league_id = "522458773317046272", season = 2020)
-    jml_league <- ff_league(jml_conn)
-    expect_tibble(jml_league, min.rows = 1)
+  expect_tibble(dlf_league, min.rows = 1)
 
-    bestball_conn <- ff_connect(platform = "sleeper", league_id = "711961723149553664", season = 2021)
-    bestball_league <- ff_league(bestball_conn)
-    expect_tibble(bestball_league, min.rows = 1)
+  jml_conn <- ff_connect(platform = "sleeper", league_id = "522458773317046272", season = 2020)
+  jml_league <- ff_league(jml_conn)
+  expect_tibble(jml_league, min.rows = 1)
 
-    got_conn <- fleaflicker_connect(2020, 206154)
-    got_league <- ff_league(got_conn)
-    expect_tibble(got_league, min.rows = 1)
+  bestball_conn <- ff_connect(platform = "sleeper", league_id = "711961723149553664", season = 2021)
+  bestball_league <- ff_league(bestball_conn)
+  expect_tibble(bestball_league, min.rows = 1)
 
-    espn_conn <- espn_connect(season = 2020, league_id = 899513)
-    espn_league <- ff_league(espn_conn)
-    expect_tibble(espn_league, min.rows = 1)
-  })
+  got_conn <- fleaflicker_connect(2020, 206154)
+  got_league <- ff_league(got_conn)
+  expect_tibble(got_league, min.rows = 1)
+
+  espn_conn <- espn_connect(season = 2020, league_id = 899513)
+  espn_league <- ff_league(espn_conn)
+  expect_tibble(espn_league, min.rows = 1)
 })

--- a/tests/testthat/test-ff_playerscores.R
+++ b/tests/testthat/test-ff_playerscores.R
@@ -1,6 +1,5 @@
 with_mock_api({
   test_that("ff_playerscores returns a tibble of player scores", {
-    skippy()
     sfb_conn <- mfl_connect(2020, 65443)
     sfb_playerscores <- ff_playerscores(sfb_conn, 2019, "AVG")
 

--- a/tests/testthat/test-ff_playerscores.R
+++ b/tests/testthat/test-ff_playerscores.R
@@ -1,21 +1,21 @@
-with_mock_api({
-  test_that("ff_playerscores returns a tibble of player scores", {
-    sfb_conn <- mfl_connect(2020, 65443)
-    sfb_playerscores <- ff_playerscores(sfb_conn, 2019, "AVG")
+test_that("ff_playerscores returns a tibble of player scores", {
+  local_mock_api()
 
-    expect_tibble(sfb_playerscores, min.rows = 100)
+  sfb_conn <- mfl_connect(2020, 65443)
+  sfb_playerscores <- ff_playerscores(sfb_conn, 2019, "AVG")
 
-    jml_conn <- ff_connect(platform = "sleeper", league_id = "522458773317046272", season = 2020)
-    expect_warning(ff_playerscores(jml_conn))
+  expect_tibble(sfb_playerscores, min.rows = 100)
 
-    joe_conn <- fleaflicker_connect(2020, 312861)
-    joe_playerscores <- ff_playerscores(joe_conn, page_limit = 2)
+  jml_conn <- ff_connect(platform = "sleeper", league_id = "522458773317046272", season = 2020)
+  expect_warning(ff_playerscores(jml_conn))
 
-    expect_tibble(joe_playerscores, min.rows = 50)
+  joe_conn <- fleaflicker_connect(2020, 312861)
+  joe_playerscores <- ff_playerscores(joe_conn, page_limit = 2)
 
-    tony_conn <- espn_connect(season = 2020, league_id = 899513)
-    tony_playerscores <- ff_playerscores(tony_conn, limit = 5)
+  expect_tibble(joe_playerscores, min.rows = 50)
 
-    expect_tibble(tony_playerscores, min.rows = 5)
-  })
+  tony_conn <- espn_connect(season = 2020, league_id = 899513)
+  tony_playerscores <- ff_playerscores(tony_conn, limit = 5)
+
+  expect_tibble(tony_playerscores, min.rows = 5)
 })

--- a/tests/testthat/test-ff_rosters.R
+++ b/tests/testthat/test-ff_rosters.R
@@ -1,7 +1,5 @@
 with_mock_api({
   test_that("ff_rosters returns a tibble", {
-    skippy()
-
     ssb <- mfl_connect(2020, 54040)
     ssb_rosters <- ff_rosters(ssb)
     ssb_rosters_w2 <- ff_rosters(ssb, week = 2)

--- a/tests/testthat/test-ff_rosters.R
+++ b/tests/testthat/test-ff_rosters.R
@@ -1,24 +1,24 @@
-with_mock_api({
-  test_that("ff_rosters returns a tibble", {
-    ssb <- mfl_connect(2020, 54040)
-    ssb_rosters <- ff_rosters(ssb)
-    ssb_rosters_w2 <- ff_rosters(ssb, week = 2)
-    expect_tibble(ssb_rosters, min.rows = 300)
-    expect_tibble(ssb_rosters_w2, min.rows = 300)
+test_that("ff_rosters returns a tibble", {
+  local_mock_api()
 
-    jml_conn <- sleeper_connect(league_id = "522458773317046272", season = 2020)
-    jml_rosters <- ff_rosters(jml_conn)
-    expect_tibble(jml_rosters, min.rows = 200)
+  ssb <- mfl_connect(2020, 54040)
+  ssb_rosters <- ff_rosters(ssb)
+  ssb_rosters_w2 <- ff_rosters(ssb, week = 2)
+  expect_tibble(ssb_rosters, min.rows = 300)
+  expect_tibble(ssb_rosters_w2, min.rows = 300)
 
-    joe_conn <- ff_connect(platform = "fleaflicker", league_id = 312861, season = 2020)
-    joe_rosters <- ff_rosters(joe_conn)
-    expect_tibble(joe_rosters, min.rows = 200)
+  jml_conn <- sleeper_connect(league_id = "522458773317046272", season = 2020)
+  jml_rosters <- ff_rosters(jml_conn)
+  expect_tibble(jml_rosters, min.rows = 200)
 
-    tony_conn <- espn_connect(season = 2020, league_id = 899513)
-    tony_rosters <- ff_rosters(tony_conn)
-    tony_rosters_w2 <- ff_rosters(tony_conn, week = 2)
+  joe_conn <- ff_connect(platform = "fleaflicker", league_id = 312861, season = 2020)
+  joe_rosters <- ff_rosters(joe_conn)
+  expect_tibble(joe_rosters, min.rows = 200)
 
-    expect_tibble(tony_rosters, min.rows = 200)
-    expect_tibble(tony_rosters_w2, min.rows = 200)
-  })
+  tony_conn <- espn_connect(season = 2020, league_id = 899513)
+  tony_rosters <- ff_rosters(tony_conn)
+  tony_rosters_w2 <- ff_rosters(tony_conn, week = 2)
+
+  expect_tibble(tony_rosters, min.rows = 200)
+  expect_tibble(tony_rosters_w2, min.rows = 200)
 })

--- a/tests/testthat/test-ff_schedule.R
+++ b/tests/testthat/test-ff_schedule.R
@@ -1,29 +1,29 @@
-with_mock_api({
-  test_that("ff_schedule returns a tibble", {
-    dlf <- mfl_connect(2019, 37920)
-    dlf_schedule <- ff_schedule(dlf)
+test_that("ff_schedule returns a tibble", {
+  local_mock_api()
 
-    ssb <- mfl_connect(2020, 54040)
-    ssb_schedule <- ff_schedule(ssb)
+  dlf <- mfl_connect(2019, 37920)
+  dlf_schedule <- ff_schedule(dlf)
 
-    fog <- mfl_connect(2019, 12608)
-    fog_schedule <- ff_schedule(fog)
+  ssb <- mfl_connect(2020, 54040)
+  ssb_schedule <- ff_schedule(ssb)
 
-    jml_conn <- sleeper_connect(league_id = "522458773317046272", season = 2020)
-    jml_schedule <- ff_schedule(jml_conn)
+  fog <- mfl_connect(2019, 12608)
+  fog_schedule <- ff_schedule(fog)
 
-    joe_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
-    joe_schedule <- ff_schedule(joe_conn, week = 4)
+  jml_conn <- sleeper_connect(league_id = "522458773317046272", season = 2020)
+  jml_schedule <- ff_schedule(jml_conn)
 
-    tony_conn <- espn_connect(season = 2020, league_id = 899513)
-    tony_schedule <- ff_schedule(tony_conn)
+  joe_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
+  joe_schedule <- ff_schedule(joe_conn, week = 4)
 
-    expect_tibble(ssb_schedule, min.rows = 100)
-    expect_tibble(dlf_schedule, min.rows = 100)
-    expect_tibble(jml_schedule, min.rows = 100)
-    expect_null(fog_schedule)
+  tony_conn <- espn_connect(season = 2020, league_id = 899513)
+  tony_schedule <- ff_schedule(tony_conn)
 
-    expect_tibble(joe_schedule, min.rows = 16)
-    expect_tibble(tony_schedule, min.rows = 100)
-  })
+  expect_tibble(ssb_schedule, min.rows = 100)
+  expect_tibble(dlf_schedule, min.rows = 100)
+  expect_tibble(jml_schedule, min.rows = 100)
+  expect_null(fog_schedule)
+
+  expect_tibble(joe_schedule, min.rows = 16)
+  expect_tibble(tony_schedule, min.rows = 100)
 })

--- a/tests/testthat/test-ff_schedule.R
+++ b/tests/testthat/test-ff_schedule.R
@@ -1,6 +1,5 @@
 with_mock_api({
   test_that("ff_schedule returns a tibble", {
-    skippy()
     dlf <- mfl_connect(2019, 37920)
     dlf_schedule <- ff_schedule(dlf)
 

--- a/tests/testthat/test-ff_scoring.R
+++ b/tests/testthat/test-ff_scoring.R
@@ -1,6 +1,5 @@
 with_mock_api({
   test_that("ff_scoring returns a tibble", {
-    skippy()
     dlf <- mfl_connect(2019, 37920)
     dlf_scoring <- ff_scoring(dlf)
 

--- a/tests/testthat/test-ff_scoring.R
+++ b/tests/testthat/test-ff_scoring.R
@@ -1,22 +1,22 @@
-with_mock_api({
-  test_that("ff_scoring returns a tibble", {
-    dlf <- mfl_connect(2019, 37920)
-    dlf_scoring <- ff_scoring(dlf)
+test_that("ff_scoring returns a tibble", {
+  local_mock_api()
 
-    jml_conn <- sleeper_connect(league_id = "522458773317046272", season = 2020)
-    jml_scoring <- ff_scoring(jml_conn)
+  dlf <- mfl_connect(2019, 37920)
+  dlf_scoring <- ff_scoring(dlf)
 
-    joe_conn <- ff_connect(platform = "fleaflicker", league_id = 312861, season = 2020)
-    joe_scoring <- ff_scoring(joe_conn)
+  jml_conn <- sleeper_connect(league_id = "522458773317046272", season = 2020)
+  jml_scoring <- ff_scoring(jml_conn)
 
-    tony_conn <- espn_connect(season = 2020, league_id = 899513)
-    tony_scoring <- ff_scoring(tony_conn)
+  joe_conn <- ff_connect(platform = "fleaflicker", league_id = 312861, season = 2020)
+  joe_scoring <- ff_scoring(joe_conn)
 
-    expect_tibble(dlf_scoring, min.rows = 10)
-    expect_tibble(jml_scoring, min.rows = 10)
-    expect_tibble(joe_scoring, min.rows = 10)
-    expect_tibble(tony_scoring, min.rows = 10)
-  })
+  tony_conn <- espn_connect(season = 2020, league_id = 899513)
+  tony_scoring <- ff_scoring(tony_conn)
+
+  expect_tibble(dlf_scoring, min.rows = 10)
+  expect_tibble(jml_scoring, min.rows = 10)
+  expect_tibble(joe_scoring, min.rows = 10)
+  expect_tibble(tony_scoring, min.rows = 10)
 })
 
 test_that("ff_scoring for templates return tibbles", {

--- a/tests/testthat/test-ff_scoringhistory.R
+++ b/tests/testthat/test-ff_scoringhistory.R
@@ -1,15 +1,14 @@
 with_mock_api({
   test_that("ff_scoringhistory returns a tibble of player scores", {
-    skippy()
 
     if (!identical(Sys.getenv("MOCK_BYPASS"), "true")) {
       testthat::local_mock(
         nflfastr_weekly = function(seasons, type) {
-          if(type == "offense") return(readRDS("ffscrapr-tests-main/gh_nflfastr/player_stats.rds"))
-          if(type == "kicking") return(readRDS("ffscrapr-tests-main/gh_nflfastr/kicker_stats.rds"))
+          if(type == "offense") return(readRDS(file.path(cache_path, "gh_nflfastr/player_stats.rds")))
+          if(type == "kicking") return(readRDS(file.path(cache_path, "gh_nflfastr/kicker_stats.rds")))
           },
         nflfastr_rosters = function(seasons) {
-          purrr::map_df(seasons, ~ readRDS(glue::glue("ffscrapr-tests-main/gh_nflfastr/roster_{.x}.rds")))
+          purrr::map_df(seasons, ~ readRDS(file.path(cache_path, glue::glue("gh_nflfastr/roster_{.x}.rds"))))
         }
       )
     }

--- a/tests/testthat/test-ff_scoringhistory.R
+++ b/tests/testthat/test-ff_scoringhistory.R
@@ -1,42 +1,41 @@
-with_mock_api({
-  test_that("ff_scoringhistory returns a tibble of player scores", {
+test_that("ff_scoringhistory returns a tibble of player scores", {
+  local_mock_api()
 
-    if (!identical(Sys.getenv("MOCK_BYPASS"), "true")) {
-      testthat::local_mock(
-        nflfastr_weekly = function(seasons, type) {
-          if(type == "offense") return(readRDS(file.path(cache_path, "gh_nflfastr/player_stats.rds")))
-          if(type == "kicking") return(readRDS(file.path(cache_path, "gh_nflfastr/kicker_stats.rds")))
-          },
-        nflfastr_rosters = function(seasons) {
-          purrr::map_df(seasons, ~ readRDS(file.path(cache_path, glue::glue("gh_nflfastr/roster_{.x}.rds"))))
-        }
-      )
-    }
+  if (!identical(Sys.getenv("MOCK_BYPASS"), "true")) {
+    testthat::local_mock(
+      nflfastr_weekly = function(seasons, type) {
+        if(type == "offense") return(readRDS(file.path(cache_path, "gh_nflfastr/player_stats.rds")))
+        if(type == "kicking") return(readRDS(file.path(cache_path, "gh_nflfastr/kicker_stats.rds")))
+        },
+      nflfastr_rosters = function(seasons) {
+        purrr::map_df(seasons, ~ readRDS(file.path(cache_path, glue::glue("gh_nflfastr/roster_{.x}.rds"))))
+      }
+    )
+  }
 
-    sfb_conn <- mfl_connect(2020, 65443)
-    sfb_scoringhistory <- ff_scoringhistory(sfb_conn, 2019:2020)
-    expect_tibble(sfb_scoringhistory, min.rows = 6000)
+  sfb_conn <- mfl_connect(2020, 65443)
+  sfb_scoringhistory <- ff_scoringhistory(sfb_conn, 2019:2020)
+  expect_tibble(sfb_scoringhistory, min.rows = 6000)
 
-    foureight_conn <- mfl_connect(2020, 22627)
-    foureight_scoringhistory <- ff_scoringhistory(foureight_conn, 2019:2020)
-    expect_tibble(foureight_scoringhistory, min.rows = 6000)
-    expect_lt(max(foureight_scoringhistory$points), 60)
+  foureight_conn <- mfl_connect(2020, 22627)
+  foureight_scoringhistory <- ff_scoringhistory(foureight_conn, 2019:2020)
+  expect_tibble(foureight_scoringhistory, min.rows = 6000)
+  expect_lt(max(foureight_scoringhistory$points), 60)
 
-    jml_conn <- ff_connect(platform = "sleeper", league_id = "522458773317046272", season = 2020)
-    jml_scoringhistory <- ff_scoringhistory(jml_conn, 2019:2020)
-    expect_tibble(jml_scoringhistory, min.rows = 6000)
+  jml_conn <- ff_connect(platform = "sleeper", league_id = "522458773317046272", season = 2020)
+  jml_scoringhistory <- ff_scoringhistory(jml_conn, 2019:2020)
+  expect_tibble(jml_scoringhistory, min.rows = 6000)
 
-    joe_conn <- fleaflicker_connect(2020, 312861)
-    joe_scoringhistory <- ff_scoringhistory(joe_conn, 2019:2020)
-    expect_tibble(joe_scoringhistory, min.rows = 6000)
+  joe_conn <- fleaflicker_connect(2020, 312861)
+  joe_scoringhistory <- ff_scoringhistory(joe_conn, 2019:2020)
+  expect_tibble(joe_scoringhistory, min.rows = 6000)
 
-    tony_conn <- espn_connect(season = 2020, league_id = 899513)
-    tony_scoringhistory <- ff_scoringhistory(tony_conn, 2019:2020)
-    expect_tibble(tony_scoringhistory, min.rows = 3000)
+  tony_conn <- espn_connect(season = 2020, league_id = 899513)
+  tony_scoringhistory <- ff_scoringhistory(tony_conn, 2019:2020)
+  expect_tibble(tony_scoringhistory, min.rows = 3000)
 
-    template_scoringhistory <- ff_template(scoring_type = "sfb11", roster_type = "sfb11") %>%
-      ff_scoringhistory(2019:2020)
+  template_scoringhistory <- ff_template(scoring_type = "sfb11", roster_type = "sfb11") %>%
+    ff_scoringhistory(2019:2020)
 
-    expect_tibble(template_scoringhistory, min.rows = 6000)
-  })
+  expect_tibble(template_scoringhistory, min.rows = 6000)
 })

--- a/tests/testthat/test-ff_standings.R
+++ b/tests/testthat/test-ff_standings.R
@@ -1,9 +1,9 @@
 test_that("ff_standings returns a tibble for each platform currently programmed", {
   local_mock_api()
-  dlf_conn <- ff_connect("mfl", 37920, season = 2019)
-  dlf_standings <- ff_standings(dlf_conn)
+  # dlf_conn <- ff_connect("mfl", 37920, season = 2019)
+  # dlf_standings <- ff_standings(dlf_conn)
 
-  expect_tibble(dlf_standings, any.missing = FALSE, min.rows = 16)
+  # expect_tibble(dlf_standings, any.missing = FALSE, min.rows = 16)
 
   jml_conn <- ff_connect("sleeper", "522458773317046272", season = 2020)
   jml_standings <- ff_standings(jml_conn)

--- a/tests/testthat/test-ff_standings.R
+++ b/tests/testthat/test-ff_standings.R
@@ -1,6 +1,5 @@
 with_mock_api({
   test_that("ff_standings returns a tibble for each platform currently programmed", {
-    skippy()
     dlf_conn <- ff_connect("mfl", 37920, season = 2019)
     dlf_standings <- ff_standings(dlf_conn)
 

--- a/tests/testthat/test-ff_standings.R
+++ b/tests/testthat/test-ff_standings.R
@@ -1,29 +1,28 @@
-with_mock_api({
-  test_that("ff_standings returns a tibble for each platform currently programmed", {
-    dlf_conn <- ff_connect("mfl", 37920, season = 2019)
-    dlf_standings <- ff_standings(dlf_conn)
+test_that("ff_standings returns a tibble for each platform currently programmed", {
+  local_mock_api()
+  dlf_conn <- ff_connect("mfl", 37920, season = 2019)
+  dlf_standings <- ff_standings(dlf_conn)
 
-    expect_tibble(dlf_standings, any.missing = FALSE, min.rows = 16)
+  expect_tibble(dlf_standings, any.missing = FALSE, min.rows = 16)
 
-    jml_conn <- ff_connect("sleeper", "522458773317046272", season = 2020)
-    jml_standings <- ff_standings(jml_conn)
+  jml_conn <- ff_connect("sleeper", "522458773317046272", season = 2020)
+  jml_standings <- ff_standings(jml_conn)
 
-    dlp <- sleeper_connect(2020, "521379020332068864")
-    dlp_standings <- ff_standings(dlp)
+  dlp <- sleeper_connect(2020, "521379020332068864")
+  dlp_standings <- ff_standings(dlp)
 
-    got_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
-    got_standings <- ff_standings(got_conn, include_allplay = FALSE, include_potentialpoints = FALSE)
+  got_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
+  got_standings <- ff_standings(got_conn, include_allplay = FALSE, include_potentialpoints = FALSE)
 
-    got_schedule <- ff_schedule(got_conn, week = 4)
-    got_potentialpoints <- .flea_add_potentialpoints(got_schedule, got_conn)
+  got_schedule <- ff_schedule(got_conn, week = 4)
+  got_potentialpoints <- .flea_add_potentialpoints(got_schedule, got_conn)
 
-    tony_conn <- espn_connect(season = 2020, league_id = 899513)
-    tony_standings <- ff_standings(tony_conn)
+  tony_conn <- espn_connect(season = 2020, league_id = 899513)
+  tony_standings <- ff_standings(tony_conn)
 
-    expect_tibble(jml_standings, any.missing = FALSE, nrows = 12)
-    expect_tibble(dlp_standings, any.missing = FALSE, nrows = 12)
-    expect_tibble(got_standings, any.missing = FALSE, nrows = 16)
-    expect_tibble(got_potentialpoints, nrows = 16)
-    expect_tibble(tony_standings, any.missing = FALSE, nrows = 10)
-  })
+  expect_tibble(jml_standings, any.missing = FALSE, nrows = 12)
+  expect_tibble(dlp_standings, any.missing = FALSE, nrows = 12)
+  expect_tibble(got_standings, any.missing = FALSE, nrows = 16)
+  expect_tibble(got_potentialpoints, nrows = 16)
+  expect_tibble(tony_standings, any.missing = FALSE, nrows = 10)
 })

--- a/tests/testthat/test-ff_starterpositions.R
+++ b/tests/testthat/test-ff_starterpositions.R
@@ -1,7 +1,5 @@
 with_mock_api({
   test_that("ff_starter_positions returns a tibble of starter positions", {
-    skippy()
-
     dlf <- mfl_connect(2020, 37920)
     dlf_starter_positions <- ff_starter_positions(dlf)
 

--- a/tests/testthat/test-ff_starterpositions.R
+++ b/tests/testthat/test-ff_starterpositions.R
@@ -1,25 +1,25 @@
-with_mock_api({
-  test_that("ff_starter_positions returns a tibble of starter positions", {
-    dlf <- mfl_connect(2020, 37920)
-    dlf_starter_positions <- ff_starter_positions(dlf)
+test_that("ff_starter_positions returns a tibble of starter positions", {
+  local_mock_api()
 
-    expect_tibble(dlf_starter_positions, min.rows = 4)
+  dlf <- mfl_connect(2020, 37920)
+  dlf_starter_positions <- ff_starter_positions(dlf)
 
-    jml_conn <- sleeper_connect(league_id = "522458773317046272", season = 2020)
-    jml_starter_positions <- ff_starter_positions(jml_conn)
+  expect_tibble(dlf_starter_positions, min.rows = 4)
 
-    expect_tibble(jml_starter_positions, min.rows = 4)
+  jml_conn <- sleeper_connect(league_id = "522458773317046272", season = 2020)
+  jml_starter_positions <- ff_starter_positions(jml_conn)
 
-    got_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
-    got_starter_positions <- ff_starter_positions(got_conn)
+  expect_tibble(jml_starter_positions, min.rows = 4)
 
-    expect_tibble(got_starter_positions, min.rows = 10)
+  got_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
+  got_starter_positions <- ff_starter_positions(got_conn)
 
-    tony_conn <- espn_connect(season = 2020, league_id = 899513)
-    tony_starter_positions <- ff_starter_positions(tony_conn)
+  expect_tibble(got_starter_positions, min.rows = 10)
 
-    expect_tibble(tony_starter_positions, min.rows = 5)
-  })
+  tony_conn <- espn_connect(season = 2020, league_id = 899513)
+  tony_starter_positions <- ff_starter_positions(tony_conn)
+
+  expect_tibble(tony_starter_positions, min.rows = 5)
 })
 
 test_that("ff_scoring for templates return tibbles", {

--- a/tests/testthat/test-ff_starters.R
+++ b/tests/testthat/test-ff_starters.R
@@ -1,7 +1,5 @@
 with_mock_api({
   test_that("ff_starters returns a tibble of starters", {
-    skippy()
-
     dlf <- mfl_connect(2020, 37920)
     dlf_starters <- ff_starters(dlf, week = c(1:3), year = 2020)
 

--- a/tests/testthat/test-ff_starters.R
+++ b/tests/testthat/test-ff_starters.R
@@ -1,25 +1,25 @@
-with_mock_api({
-  test_that("ff_starters returns a tibble of starters", {
-    dlf <- mfl_connect(2020, 37920)
-    dlf_starters <- ff_starters(dlf, week = c(1:3), year = 2020)
+test_that("ff_starters returns a tibble of starters", {
+  local_mock_api()
 
-    expect_tibble(dlf_starters, min.rows = 100)
+  dlf <- mfl_connect(2020, 37920)
+  dlf_starters <- ff_starters(dlf, week = c(1:3), year = 2020)
 
-    jml_conn <- sleeper_connect(league_id = "522458773317046272", season = 2020)
-    jml_starters <- ff_starters(jml_conn, week = 1:4)
+  expect_tibble(dlf_starters, min.rows = 100)
 
-    expect_tibble(jml_starters, min.rows = 100)
+  jml_conn <- sleeper_connect(league_id = "522458773317046272", season = 2020)
+  jml_starters <- ff_starters(jml_conn, week = 1:4)
 
-    got_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
-    got_starters <- ff_starters(got_conn, week = 4)
+  expect_tibble(jml_starters, min.rows = 100)
 
-    expect_tibble(got_starters, min.rows = 100)
+  got_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
+  got_starters <- ff_starters(got_conn, week = 4)
 
-    tony_conn <- espn_connect(season = 2020, league_id = 899513)
-    tony_starters <- ff_starters(tony_conn, weeks = 1:2)
-    tony_potentialpoints <- espn_potentialpoints(tony_conn, weeks = 1:2)
+  expect_tibble(got_starters, min.rows = 100)
 
-    expect_tibble(tony_starters, min.rows = 100)
-    expect_tibble(tony_potentialpoints, min.rows = 100)
-  })
+  tony_conn <- espn_connect(season = 2020, league_id = 899513)
+  tony_starters <- ff_starters(tony_conn, weeks = 1:2)
+  tony_potentialpoints <- espn_potentialpoints(tony_conn, weeks = 1:2)
+
+  expect_tibble(tony_starters, min.rows = 100)
+  expect_tibble(tony_potentialpoints, min.rows = 100)
 })

--- a/tests/testthat/test-ff_transactions.R
+++ b/tests/testthat/test-ff_transactions.R
@@ -1,47 +1,47 @@
-with_mock_api({
-  test_that("ff_transactions returns a tibble of transactions", {
-    ssb <- mfl_connect(2019, 54040)
-    ssb_transactions <- ff_transactions(ssb)
+test_that("ff_transactions returns a tibble of transactions", {
+  local_mock_api()
 
-    dlf <- mfl_connect(2020, 37920)
-    dlf_transactions <- ff_transactions(dlf)
+  ssb <- mfl_connect(2019, 54040)
+  ssb_transactions <- ff_transactions(ssb)
 
-    expect_tibble(ssb_transactions, min.rows = 100)
-    expect_tibble(dlf_transactions, min.rows = 100)
+  dlf <- mfl_connect(2020, 37920)
+  dlf_transactions <- ff_transactions(dlf)
 
-    jml_conn <- ff_connect(platform = "sleeper", league_id = "522458773317046272", season = 2020)
-    jml_transactions <- ff_transactions(jml_conn, week = 1:9)
+  expect_tibble(ssb_transactions, min.rows = 100)
+  expect_tibble(dlf_transactions, min.rows = 100)
 
-    ## Sleeper - test for simultaneous drops (#246) ##
-    templer_conn <- ff_connect(platform = "sleeper", league_id = "515566249837142016", season = 2020)
-    templer_transactions <- ff_transactions(templer_conn, week = 1:9)
+  jml_conn <- ff_connect(platform = "sleeper", league_id = "522458773317046272", season = 2020)
+  jml_transactions <- ff_transactions(jml_conn, week = 1:9)
 
-    ## Sleeper - test for waiver priority handling (#299) ##
-    fflm <- ff_connect(platform = "sleeper", league_id = "649647301366755328", season = 2021)
-    fflm_transactions <- ff_transactions(fflm, week = 1)
+  ## Sleeper - test for simultaneous drops (#246) ##
+  templer_conn <- ff_connect(platform = "sleeper", league_id = "515566249837142016", season = 2020)
+  templer_transactions <- ff_transactions(templer_conn, week = 1:9)
 
-    expect_tibble(jml_transactions, min.rows = 20)
-    expect_tibble(templer_transactions, min.rows = 20)
-    expect_tibble(fflm_transactions, min.rows = 20)
+  ## Sleeper - test for waiver priority handling (#299) ##
+  fflm <- ff_connect(platform = "sleeper", league_id = "649647301366755328", season = 2021)
+  fflm_transactions <- ff_transactions(fflm, week = 1)
 
-    got_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
-    got_transactions <- ff_transactions(got_conn, franchise_id = 1373475)
+  expect_tibble(jml_transactions, min.rows = 20)
+  expect_tibble(templer_transactions, min.rows = 20)
+  expect_tibble(fflm_transactions, min.rows = 20)
 
-    aaa_conn <- fleaflicker_connect(season = 2020, league_id = 312861)
-    aaa_transactions <- ff_transactions(aaa_conn, franchise_id = 1581722)
+  got_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
+  got_transactions <- ff_transactions(got_conn, franchise_id = 1373475)
 
-    expect_tibble(aaa_transactions)
-    expect_tibble(got_transactions)
+  aaa_conn <- fleaflicker_connect(season = 2020, league_id = 312861)
+  aaa_transactions <- ff_transactions(aaa_conn, franchise_id = 1581722)
 
-    dlp_conn <- espn_connect(
-      season = 2020,
-      league_id = 1178049,
-      swid = Sys.getenv("TAN_SWID"),
-      espn_s2 = Sys.getenv("TAN_ESPN_S2")
-    )
+  expect_tibble(aaa_transactions)
+  expect_tibble(got_transactions)
 
-    dlp_transactions <- ff_transactions(dlp_conn, limit = 10)
+  dlp_conn <- espn_connect(
+    season = 2020,
+    league_id = 1178049,
+    swid = Sys.getenv("TAN_SWID"),
+    espn_s2 = Sys.getenv("TAN_ESPN_S2")
+  )
 
-    expect_tibble(dlp_transactions)
-  })
+  dlp_transactions <- ff_transactions(dlp_conn, limit = 10)
+
+  expect_tibble(dlp_transactions)
 })

--- a/tests/testthat/test-ff_transactions.R
+++ b/tests/testthat/test-ff_transactions.R
@@ -1,14 +1,14 @@
 test_that("ff_transactions returns a tibble of transactions", {
   local_mock_api()
 
-  ssb <- mfl_connect(2019, 54040)
-  ssb_transactions <- ff_transactions(ssb)
+  # ssb <- mfl_connect(2019, 54040)
+  # ssb_transactions <- ff_transactions(ssb)
 
-  dlf <- mfl_connect(2020, 37920)
-  dlf_transactions <- ff_transactions(dlf)
+  # dlf <- mfl_connect(2020, 37920)
+  # dlf_transactions <- ff_transactions(dlf)
 
-  expect_tibble(ssb_transactions, min.rows = 100)
-  expect_tibble(dlf_transactions, min.rows = 100)
+  # expect_tibble(ssb_transactions, min.rows = 100)
+  # expect_tibble(dlf_transactions, min.rows = 100)
 
   jml_conn <- ff_connect(platform = "sleeper", league_id = "522458773317046272", season = 2020)
   jml_transactions <- ff_transactions(jml_conn, week = 1:9)

--- a/tests/testthat/test-ff_transactions.R
+++ b/tests/testthat/test-ff_transactions.R
@@ -1,7 +1,5 @@
 with_mock_api({
   test_that("ff_transactions returns a tibble of transactions", {
-    skippy()
-
     ssb <- mfl_connect(2019, 54040)
     ssb_transactions <- ff_transactions(ssb)
 

--- a/tests/testthat/test-ff_userleagues.R
+++ b/tests/testthat/test-ff_userleagues.R
@@ -1,6 +1,5 @@
 with_mock_api({
   test_that("ff_userleagues works for MFL", {
-    skippy()
     conn <- mfl_connect(2020,
       user_name = "dynastyprocesstest",
       password = "test1234"
@@ -18,7 +17,6 @@ with_mock_api({
 
 with_mock_api({
   test_that("ff_userleagues works for Sleeper", {
-    skippy()
     conn <- sleeper_connect(2020,
       user_name = "solarpool"
     )
@@ -33,7 +31,6 @@ with_mock_api({
 
 with_mock_api({
   test_that("ff_userleagues works for Fleaflicker", {
-    skippy()
     conn <- fleaflicker_connect(
       season = 2020,
       user_email = "syd235@gmail.com"
@@ -49,8 +46,6 @@ with_mock_api({
 
 with_mock_api({
   test_that("ff_userleagues returns warning for ESPN", {
-    skippy()
-
     espn_conn <- espn_connect(season = 2020)
 
     expect_warning(ff_userleagues(espn_conn), regexp = "ESPN does not support")

--- a/tests/testthat/test-ff_userleagues.R
+++ b/tests/testthat/test-ff_userleagues.R
@@ -1,53 +1,52 @@
-with_mock_api({
-  test_that("ff_userleagues works for MFL", {
-    conn <- mfl_connect(2020,
-      user_name = "dynastyprocesstest",
-      password = "test1234"
-    )
+test_that("ff_userleagues works for MFL", {
+  local_mock_api()
 
-    leagues <- ff_userleagues(conn)
+  conn <- mfl_connect(2020,
+    user_name = "dynastyprocesstest",
+    password = "test1234"
+  )
 
-    expect_tibble(leagues, min.rows = 1, any.missing = FALSE)
+  leagues <- ff_userleagues(conn)
 
-    edge <- mfl_connect(2020, 54040)
-    expect_error(ff_userleagues(edge), "No authentication cookie")
-  })
+  expect_tibble(leagues, min.rows = 1, any.missing = FALSE)
+
+  edge <- mfl_connect(2020, 54040)
+  expect_error(ff_userleagues(edge), "No authentication cookie")
 })
 
+test_that("ff_userleagues works for Sleeper", {
+  local_mock_api()
 
-with_mock_api({
-  test_that("ff_userleagues works for Sleeper", {
-    conn <- sleeper_connect(2020,
-      user_name = "solarpool"
-    )
+  conn <- sleeper_connect(2020,
+    user_name = "solarpool"
+  )
 
-    full_call <- ff_userleagues(conn)
-    quick_call <- sleeper_userleagues("solarpool", 2020)
+  full_call <- ff_userleagues(conn)
+  quick_call <- sleeper_userleagues("solarpool", 2020)
 
-    expect_tibble(full_call, min.rows = 1)
-    expect_tibble(quick_call, min.rows = 1)
-  })
+  expect_tibble(full_call, min.rows = 1)
+  expect_tibble(quick_call, min.rows = 1)
 })
 
-with_mock_api({
-  test_that("ff_userleagues works for Fleaflicker", {
-    conn <- fleaflicker_connect(
-      season = 2020,
-      user_email = "syd235@gmail.com"
-    )
+test_that("ff_userleagues works for Fleaflicker", {
+  local_mock_api()
 
-    full_call <- ff_userleagues(conn)
-    quick_call <- fleaflicker_userleagues("syd235@gmail.com", 2020)
+  conn <- fleaflicker_connect(
+    season = 2020,
+    user_email = "syd235@gmail.com"
+  )
 
-    expect_tibble(full_call, min.rows = 1)
-    expect_tibble(quick_call, min.rows = 1)
-  })
+  full_call <- ff_userleagues(conn)
+  quick_call <- fleaflicker_userleagues("syd235@gmail.com", 2020)
+
+  expect_tibble(full_call, min.rows = 1)
+  expect_tibble(quick_call, min.rows = 1)
 })
 
-with_mock_api({
-  test_that("ff_userleagues returns warning for ESPN", {
-    espn_conn <- espn_connect(season = 2020)
+test_that("ff_userleagues returns warning for ESPN", {
+  local_mock_api()
 
-    expect_warning(ff_userleagues(espn_conn), regexp = "ESPN does not support")
-  })
+  espn_conn <- espn_connect(season = 2020)
+
+  expect_warning(ff_userleagues(espn_conn), regexp = "ESPN does not support")
 })

--- a/tests/testthat/test-generics.R
+++ b/tests/testthat/test-generics.R
@@ -1,6 +1,5 @@
 
 test_that("Unknown platforms return no-method errors", {
-  skippy()
   conn <- structure(list(platform = "dummy"),
     class = "dummy_platform"
   )

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -1,5 +1,4 @@
 test_that("choose season returns a character representation of a year", {
-  skippy()
   expect_type(.fn_choose_season(), "character")
   expect_equal(.fn_choose_season("2020-03-01"), "2020")
   expect_equal(.fn_choose_season("2020-02-01"), "2019")
@@ -7,7 +6,6 @@ test_that("choose season returns a character representation of a year", {
 
 with_mock_api({
   test_that(".fn_set_ratelimit creates a 'GET' function", {
-    skippy()
     expect_is(.fn_set_ratelimit(TRUE, "MFL", 1, 1)$get("http://httpbin.org"), "response")
     expect_is(.fn_set_ratelimit(FALSE, "MFL")$get("http://httpbin.org"), "response")
   })

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -4,9 +4,9 @@ test_that("choose season returns a character representation of a year", {
   expect_equal(.fn_choose_season("2020-02-01"), "2019")
 })
 
-with_mock_api({
-  test_that(".fn_set_ratelimit creates a 'GET' function", {
-    expect_is(.fn_set_ratelimit(TRUE, "MFL", 1, 1)$get("http://httpbin.org"), "response")
-    expect_is(.fn_set_ratelimit(FALSE, "MFL")$get("http://httpbin.org"), "response")
-  })
+test_that(".fn_set_ratelimit creates a 'GET' function", {
+  local_mock_api()
+
+  expect_is(.fn_set_ratelimit(TRUE, "MFL", 1, 1)$get("http://httpbin.org"), "response")
+  expect_is(.fn_set_ratelimit(FALSE, "MFL")$get("http://httpbin.org"), "response")
 })

--- a/tests/testthat/test-import_dp.R
+++ b/tests/testthat/test-import_dp.R
@@ -1,13 +1,13 @@
-with_mock_api({
-  test_that("dp_values are fetched", {
-    values <- dp_values()
-    player_values <- dp_values("values-players.csv")
-    player_ids <- dp_playerids()
+test_that("dp_values are fetched", {
+  local_mock_api()
 
-    expect_tibble(values, min.rows = 1)
-    expect_tibble(player_ids, min.rows = 1)
-    expect_tibble(player_values, min.rows = 1)
-  })
+  values <- dp_values()
+  player_values <- dp_values("values-players.csv")
+  player_ids <- dp_playerids()
+
+  expect_tibble(values, min.rows = 1)
+  expect_tibble(player_ids, min.rows = 1)
+  expect_tibble(player_values, min.rows = 1)
 })
 
 test_that("dp_cleannames removes periods, apostrophes, and suffixes", {

--- a/tests/testthat/test-import_dp.R
+++ b/tests/testthat/test-import_dp.R
@@ -1,6 +1,5 @@
 with_mock_api({
   test_that("dp_values are fetched", {
-    skippy()
     values <- dp_values()
     player_values <- dp_values("values-players.csv")
     player_ids <- dp_playerids()

--- a/tests/testthat/test-import_nflfastr.R
+++ b/tests/testthat/test-import_nflfastr.R
@@ -1,5 +1,4 @@
 test_that("nflfastr dataframes are fetched", {
-  skippy()
   skip_on_cran()
 
   weekly <- nflfastr_weekly(seasons = 2019:2020, type = "offense")

--- a/tests/testthat/test-players.R
+++ b/tests/testthat/test-players.R
@@ -1,18 +1,18 @@
-with_mock_api({
-  test_that("ff_playersish calls return a tibble", {
-    mfl <- mfl_players(mfl_connect(2020, 54040))
-    expect_tibble(mfl, min.rows = 300)
+test_that("ff_playersish calls return a tibble", {
+  local_mock_api()
 
-    sleeper <- sleeper_players()
-    expect_tibble(sleeper, min.rows = 200)
+  mfl <- mfl_players(mfl_connect(2020, 54040))
+  expect_tibble(mfl, min.rows = 300)
 
-    joe_conn <- ff_connect(platform = "fleaflicker", league_id = 312861, season = 2020)
-    flea <- fleaflicker_players(joe_conn, page_limit = 2)
-    expect_tibble(flea)
+  sleeper <- sleeper_players()
+  expect_tibble(sleeper, min.rows = 200)
 
-    conn <- espn_connect(season = 2020, league_id = 1178049)
-    espn <- espn_players(conn)
+  joe_conn <- ff_connect(platform = "fleaflicker", league_id = 312861, season = 2020)
+  flea <- fleaflicker_players(joe_conn, page_limit = 2)
+  expect_tibble(flea)
 
-    expect_tibble(espn)
-  })
+  conn <- espn_connect(season = 2020, league_id = 1178049)
+  espn <- espn_players(conn)
+
+  expect_tibble(espn)
 })

--- a/tests/testthat/test-players.R
+++ b/tests/testthat/test-players.R
@@ -1,6 +1,5 @@
 with_mock_api({
   test_that("ff_playersish calls return a tibble", {
-    skippy()
     mfl <- mfl_players(mfl_connect(2020, 54040))
     expect_tibble(mfl, min.rows = 300)
 

--- a/vignettes/espn_basics.Rmd
+++ b/vignettes/espn_basics.Rmd
@@ -22,10 +22,10 @@ eval <- TRUE
 
 tryCatch(expr = {
   
-  download.file("https://github.com/ffverse/ffscrapr-tests/archive/main.zip","f.zip")
+  download.file("https://github.com/ffverse/ffscrapr-tests/archive/1.4.7.zip","f.zip")
   unzip('f.zip', exdir = ".")
   
-  httptest::.mockPaths(new = "ffscrapr-tests-main")},
+  httptest::.mockPaths(new = "ffscrapr-tests-1.4.7")},
   warning = function(e) eval <<- FALSE,
   error = function(e) eval <<- FALSE)
 
@@ -160,6 +160,6 @@ In this vignette, I've used only a few functions: ff_connect, ff_league, ff_rost
 ```{r include = FALSE}
 httptest::stop_mocking()
 
-unlink(c("ffscrapr-tests-main","f.zip"), recursive = TRUE, force = TRUE)
+unlink(c("ffscrapr-tests-1.4.7","f.zip"), recursive = TRUE, force = TRUE)
 ```
 

--- a/vignettes/espn_getendpoint.Rmd
+++ b/vignettes/espn_getendpoint.Rmd
@@ -22,10 +22,10 @@ eval <- TRUE
 
 tryCatch(expr = {
   
-  download.file("https://github.com/ffverse/ffscrapr-tests/archive/main.zip","f.zip")
+  download.file("https://github.com/ffverse/ffscrapr-tests/archive/1.4.7.zip","f.zip")
   unzip('f.zip', exdir = ".")
   
-  httptest::.mockPaths(new = "ffscrapr-tests-main")},
+  httptest::.mockPaths(new = "ffscrapr-tests-1.4.7")},
   warning = function(e) eval <<- FALSE,
   error = function(e) eval <<- FALSE)
 
@@ -155,5 +155,5 @@ Many of the API endpoints are being researched in other languages and you might 
 ```{r include = FALSE}
 httptest::stop_mocking()
 
-unlink(c("ffscrapr-tests-main","f.zip"), recursive = TRUE, force = TRUE)
+unlink(c("ffscrapr-tests-1.4.7","f.zip"), recursive = TRUE, force = TRUE)
 ```

--- a/vignettes/fleaflicker_basics.Rmd
+++ b/vignettes/fleaflicker_basics.Rmd
@@ -23,10 +23,10 @@ eval <- TRUE
 
 tryCatch(expr = {
   
-  download.file("https://github.com/ffverse/ffscrapr-tests/archive/main.zip","f.zip")
+  download.file("https://github.com/ffverse/ffscrapr-tests/archive/1.4.7.zip","f.zip")
   unzip('f.zip', exdir = ".")
   
-  httptest::.mockPaths(new = "ffscrapr-tests-main")},
+  httptest::.mockPaths(new = "ffscrapr-tests-1.4.7")},
   warning = function(e) eval <<- FALSE,
   error = function(e) eval <<- FALSE)
 
@@ -162,6 +162,6 @@ In this vignette, I've used only a few functions: ff_connect, ff_league, ff_rost
 ```{r include = FALSE}
 httptest::stop_mocking()
 
-unlink(c("ffscrapr-tests-main","f.zip"), recursive = TRUE, force = TRUE)
+unlink(c("ffscrapr-tests-1.4.7","f.zip"), recursive = TRUE, force = TRUE)
 ```
 

--- a/vignettes/fleaflicker_getendpoint.Rmd
+++ b/vignettes/fleaflicker_getendpoint.Rmd
@@ -22,10 +22,10 @@ eval <- TRUE
 
 tryCatch(expr = {
   
-  download.file("https://github.com/ffverse/ffscrapr-tests/archive/main.zip","f.zip")
+  download.file("https://github.com/ffverse/ffscrapr-tests/archive/1.4.7.zip","f.zip")
   unzip('f.zip', exdir = ".")
   
-  httptest::.mockPaths(new = "ffscrapr-tests-main")},
+  httptest::.mockPaths(new = "ffscrapr-tests-1.4.7")},
   warning = function(e) eval <<- FALSE,
   error = function(e) eval <<- FALSE)
 
@@ -123,6 +123,6 @@ From here, you can keep unravelling - including the "viewingActualPoints" and "v
 ```{r include = FALSE}
 httptest::stop_mocking()
 
-unlink(c("ffscrapr-tests-main","f.zip"), recursive = TRUE, force = TRUE)
+unlink(c("ffscrapr-tests-1.4.7","f.zip"), recursive = TRUE, force = TRUE)
 ```
 

--- a/vignettes/fleaflicker_getendpoint.Rmd
+++ b/vignettes/fleaflicker_getendpoint.Rmd
@@ -90,7 +90,7 @@ df_scoreboard <- response_scoreboard %>%
   purrr::pluck("content","games") %>% 
   tibble::tibble() %>% 
   tidyr::unnest_wider(1) %>% 
-  dplyr::mutate_at(c("away","home"),purrr::map_chr,purrr::pluck,"franchise_name"="name") %>% 
+  dplyr::mutate_at(c("away","home"),purrr::map_chr,purrr::pluck,"name") %>% 
   dplyr::mutate_at(c("homeScore","awayScore"),purrr::map_dbl,purrr::pluck,"score","value")
 
 head(df_scoreboard)

--- a/vignettes/mfl_basics.Rmd
+++ b/vignettes/mfl_basics.Rmd
@@ -22,10 +22,10 @@ eval <- TRUE
 
 tryCatch(expr = {
   
-  download.file("https://github.com/ffverse/ffscrapr-tests/archive/main.zip","f.zip")
+  download.file("https://github.com/ffverse/ffscrapr-tests/archive/1.4.7.zip","f.zip")
   unzip('f.zip', exdir = ".")
   
-  httptest::.mockPaths(new = "ffscrapr-tests-main")},
+  httptest::.mockPaths(new = "ffscrapr-tests-1.4.7")},
   warning = function(e) eval <<- FALSE,
   error = function(e) eval <<- FALSE)
 
@@ -157,6 +157,6 @@ Now that you've gotten this far, why not check out some of the other possibiliti
 ```{r include = FALSE}
 httptest::stop_mocking()
 
-unlink(c("ffscrapr-tests-main","f.zip"), recursive = TRUE, force = TRUE)
+unlink(c("ffscrapr-tests-1.4.7","f.zip"), recursive = TRUE, force = TRUE)
 ```
 

--- a/vignettes/mfl_getendpoint.Rmd
+++ b/vignettes/mfl_getendpoint.Rmd
@@ -22,10 +22,10 @@ eval <- TRUE
 
 tryCatch(expr = {
   
-  download.file("https://github.com/ffverse/ffscrapr-tests/archive/main.zip","f.zip")
+  download.file("https://github.com/ffverse/ffscrapr-tests/archive/1.4.7.zip","f.zip")
   unzip('f.zip', exdir = ".")
   
-  httptest::.mockPaths(new = "ffscrapr-tests-main")},
+  httptest::.mockPaths(new = "ffscrapr-tests-1.4.7")},
   warning = function(e) eval <<- FALSE,
   error = function(e) eval <<- FALSE)
 
@@ -104,5 +104,5 @@ head(fog_tradebait)
 ```{r include = FALSE}
 httptest::stop_mocking()
 
-unlink(c("ffscrapr-tests-main","f.zip"), recursive = TRUE, force = TRUE)
+unlink(c("ffscrapr-tests-1.4.7","f.zip"), recursive = TRUE, force = TRUE)
 ```

--- a/vignettes/sleeper_basics.Rmd
+++ b/vignettes/sleeper_basics.Rmd
@@ -23,10 +23,10 @@ eval <- TRUE
 
 tryCatch(expr = {
   
-  download.file("https://github.com/ffverse/ffscrapr-tests/archive/main.zip","f.zip")
+  download.file("https://github.com/ffverse/ffscrapr-tests/archive/1.4.7.zip","f.zip")
   unzip('f.zip', exdir = ".")
   
-  httptest::.mockPaths(new = "ffscrapr-tests-main")},
+  httptest::.mockPaths(new = "ffscrapr-tests-1.4.7")},
   warning = function(e) eval <<- FALSE,
   error = function(e) eval <<- FALSE)
 
@@ -167,6 +167,6 @@ In this vignette, I've used ~three functions: ff_connect, ff_league, and ff_rost
 ```{r include = FALSE}
 httptest::stop_mocking()
 
-unlink(c("ffscrapr-tests-main","f.zip"), recursive = TRUE, force = TRUE)
+unlink(c("ffscrapr-tests-1.4.7","f.zip"), recursive = TRUE, force = TRUE)
 ```
 

--- a/vignettes/sleeper_getendpoint.Rmd
+++ b/vignettes/sleeper_getendpoint.Rmd
@@ -22,10 +22,10 @@ eval <- TRUE
 
 tryCatch(expr = {
   
-  download.file("https://github.com/ffverse/ffscrapr-tests/archive/main.zip","f.zip")
+  download.file("https://github.com/ffverse/ffscrapr-tests/archive/1.4.7.zip","f.zip")
   unzip('f.zip', exdir = ".")
   
-  httptest::.mockPaths(new = "ffscrapr-tests-main")},
+  httptest::.mockPaths(new = "ffscrapr-tests-1.4.7")},
   warning = function(e) eval <<- FALSE,
   error = function(e) eval <<- FALSE)
 
@@ -95,6 +95,6 @@ There - this means something to us now! As of this writing (2020-11-10), Kalen B
 ```{r include = FALSE, eval = eval}
 httptest::stop_mocking()
 
-unlink(c("ffscrapr-tests-main","f.zip"), recursive = TRUE, force = TRUE)
+unlink(c("ffscrapr-tests-1.4.7","f.zip"), recursive = TRUE, force = TRUE)
 ```
 


### PR DESCRIPTION
This was supposed to be a minimal patch to fix a failure with dev purrr, but I got a bit distracted by the challenge of running individual tests interactive, so made a couple of changes:

* I now cache the httptest shims for 24 hours to avoid downloading them every time the tests are run. This probably isn't quite right (I don't know why they are in a separate repo to begin with) and will need a bit more work for CRAN (since I think you'll need to clean up the cache directory in `R CMD check`)
* I replaced `with_mock_api()` with `local_mock_api()` so the test back traces are simpler (and clicking on them in RStudio takes you to the right place)
* I switched from `setup.R` to `helper-mocking.R` so it all works when you use `load_all()`

With that done, I still see two failing tests:

```
Error (test-ff_draftpicks.R:13): ff_draftpicks returns a tibble of draft picks
Error in `list2(...)`: object 'current_picks' not found
```

I don't see how this could ever have worked since `current_picks` isn't defined (as far as I can tell) in the necessary scope: https://github.com/hadley/ffscrapr/blob/dev-purrr/R/sleeper_draftpicks.R#L36

```
Error (/Users/hadleywickham/Desktop/ffscrapr/R/mfl_standings.R:20): ff_standings returns a tibble for each platform currently programmed
Error: GET https://api.myfantasyleague.com/2019/export?TYPE=leagueStandings&L=37920&ALL=1&JSON=1 (mfl/2019/export-89ac14.json)
```

I guess this should be mocked, but is not? 