### PR TITLE
Fixed the infinite loop within FleaFlicker trade transaction function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ffscrapr
 Title: API Client for Fantasy Football League Platforms
-Version: 1.4.7.12
+Version: 1.4.7.13
 Authors@R: 
     c(person(given = "Tan",
              family = "Ho",

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 - `ff_standings.mfl_conn()` changed to adapt to MFL API changes as documented in [2022 API release notes ](https://api.myfantasyleague.com/2022/site_news?ARTICLE=1658765676), resolves #366. (1.4.7.10)
 - `ff_starters.sleeper_conn()` bugfixed for API change (last-scored-leg -> leg) (1.4.7.11)
 - `ff_scoring()` fixed for dev purrr issues. (1.4.7.12)
+- `ff_transactions.flea_conn()` bugfixed for infinite loop problem, resolves #356 (thank you @jdegregorio!) (1.4.7.13)
 
 ---
 

--- a/R/flea_transactions.R
+++ b/R/flea_transactions.R
@@ -228,7 +228,7 @@ ff_transactions.flea_conn <- function(conn, franchise_id = NULL, ...) {
       sport = "NFL",
       filter = "TRADES_COMPLETED",
       league_id = conn$league_id,
-      result_offset = 80
+      result_offset = result_offset
     ) %>%
       purrr::pluck("content")
 


### PR DESCRIPTION
Addresses #356 - Found infinite while loop, where the result_offset was perpetually set to 80, instead of being updated each iteration.