### PR TITLE
fix `ff_starter_positions.sleeper` when the minimum of a flex position is 0, resolves #400

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ffscrapr
 Title: API Client for Fantasy Football League Platforms
-Version: 1.4.8.02
+Version: 1.4.8.03
 Authors@R: 
     c(person(given = "Tan",
              family = "Ho",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 supports mock draft retrieval also. (#395) (v1.4.8.01)
 - `ff_starters.espn_conn()` now retrieves projected scores by statSourceId which
 should be more robust (#397, thank you @logan-888!) (v1.4.8.02)
+- `ff_startpositions.sleeper_conn()` now properly handles leagues with flex
+positions that did not have dedicated posititions (#400, thank you @mcarman8!) 
+(v1.4.8.03)
 
 # ffscrapr 1.4.8
 

--- a/R/sleeper_starterpositions.R
+++ b/R/sleeper_starterpositions.R
@@ -30,8 +30,7 @@ ff_starter_positions.sleeper_conn <- function(conn, ...) {
     dplyr::mutate(
       pos = purrr::map_chr(.data$pos, unlist)
     ) %>%
-    dplyr::full_join(all_positions, by=dplyr::join_by(pos)) %>%
-    replace(is.na(.),0) %>%
+    tidyr::complete(pos = all_positions$pos, fill = list(min = 0)) %>%
     dplyr::mutate(
       total_starters = sum(.data$min, na.rm = TRUE)
     )

--- a/tests/testthat/test-ff_starterpositions.R
+++ b/tests/testthat/test-ff_starterpositions.R
@@ -11,6 +11,12 @@ test_that("ff_starter_positions returns a tibble of starter positions", {
 
   expect_tibble(jml_starter_positions, min.rows = 4)
 
+  #Test for Issue 400
+  flx_conn <- sleeper_connect(league_id = "926025334582063104", season = 2023)
+  flx_starter_positions <- ff_starter_positions(flx_conn)
+
+  expect_tibble(flx_starter_positions, min.rows = 4)
+
   got_conn <- fleaflicker_connect(season = 2020, league_id = 206154)
   got_starter_positions <- ff_starter_positions(got_conn)
 


### PR DESCRIPTION
Added individual positions to allow for flex positions to properly calculate when the minimum for a position is 0.