### PR TITLE
Add Season Parameters to Flea API and Create 2 additional detailed functions

### DIFF
--- a/R/flea_franchises.R
+++ b/R/flea_franchises.R
@@ -16,7 +16,7 @@
 #' @export
 
 ff_franchises.flea_conn <- function(conn) {
-  x <- fleaflicker_getendpoint("FetchLeagueStandings", league_id = conn$league_id, sport = "NFL") %>%
+  x <- fleaflicker_getendpoint("FetchLeagueStandings", season = conn$season, league_id = conn$league_id, sport = "NFL") %>%
     purrr::pluck("content", "divisions") %>%
     tibble::tibble() %>%
     tidyr::hoist(1, "division_id" = "id", "division_name" = "name", "teams") %>%
@@ -42,5 +42,73 @@ ff_franchises.flea_conn <- function(conn) {
       dplyr::starts_with("user")
     )))
 
+  return(x)
+}
+
+#' Get a dataframe of more detailed franchise information
+#'
+#' @param conn a conn object created by `ff_connect()`
+#'
+#' @examples
+#' \donttest{
+#' try({ # try only shown here because sometimes CRAN checks are weird
+#'   conn <- fleaflicker_connect(season = 2020, league_id = 206154)
+#'   ff_franchises(conn)
+#' }) # end try
+#' }
+#'
+#' @describeIn ff_franchises Fleaflicker: returns franchise and division information.
+#' @export
+ff_franchises.flea_conn2 <- function(conn) {
+  x <- ffscrapr::fleaflicker_getendpoint("FetchLeagueStandings", season = conn$season, league_id = conn$league_id, sport = "NFL") |>
+    purrr::pluck("content", "divisions") |>
+    tibble::tibble() |>
+    tidyr::hoist(1, "division_id" = "id", "division_name" = "name", "teams") |>
+    tidyr::unnest_longer("teams") |>
+    tidyr::hoist("teams",
+                 "franchise_id" = "id",
+                 "franchise_name" = "name",
+                 "owners"
+    ) |>
+    tidyr::unnest_longer("owners") |>
+    tidyr::hoist("owners",
+                 "user_id" = "id",
+                 "user_name" = "displayName",
+                 "user_lastlogin" = "lastSeen"
+    ) |>
+    dplyr::mutate_at("user_lastlogin", ~ (as.numeric(.x) / 1000) |> ffscrapr:::.as_datetime()) |>
+    tidyr::hoist("teams",
+                 "recordOverall" = "recordOverall",
+                 "recordDivision" = "recordDivision",
+                 "pointsFor" = "pointsFor",
+                 "pointsAgainst" = "pointsAgainst") |>
+    tidyr::hoist("pointsFor",
+                 "franchise_pointsfor" = "value") |>
+    tidyr::hoist("pointsAgainst",
+                 "franchise_pointsagainst" = "value") |>
+    tidyr::hoist("recordOverall",
+                 "franchise_wins" = "wins",
+                 "franchise_losses" = "losses",
+                 "franchise_rank" = "rank",
+                 "franchise_record"= "formatted",
+                 "winPercentage" = "winPercentage") |>
+    tidyr::hoist("winPercentage",
+                 "franchise_winpercentage" = "value") |>
+    dplyr::mutate_at("franchise_winpercentage", ~ round(.x,3)) |>
+    tidyr::hoist("recordDivision",
+                 "franchise_division_wins" = "wins",
+                 "franchise_division_losses" = "losses",
+                 "franchise_division_rank" = "rank",
+                 "franchise_division_record"= "formatted",
+                 "winPercentage" = "winPercentage") |>
+    tidyr::hoist("winPercentage",
+                 "franchise_division_winpercentage" = "value") |>
+    dplyr::mutate_at("franchise_division_winpercentage", ~ round(.x,3)) |>
+    dplyr::select(dplyr::any_of(c(
+      dplyr::starts_with("division"),
+      dplyr::starts_with("franchise"),
+      dplyr::starts_with("user")
+    )))
+  
   return(x)
 }

--- a/R/flea_playerscores.R
+++ b/R/flea_playerscores.R
@@ -25,6 +25,7 @@ ff_playerscores.flea_conn <- function(conn, page_limit = NULL, ...) {
     endpoint = "FetchPlayerListing",
     sport = "NFL",
     league_id = conn$league_id,
+    sort_season = conn$season,
     external_id_type = "SPORTRADAR",
     result_offset = result_offset
   ) %>%
@@ -41,6 +42,7 @@ ff_playerscores.flea_conn <- function(conn, page_limit = NULL, ...) {
       endpoint = "FetchPlayerListing",
       sport = "NFL",
       league_id = conn$league_id,
+      sort_season = conn$season,
       external_id_type = "SPORTRADAR",
       result_offset = result_offset
     ) %>%
@@ -71,8 +73,9 @@ ff_playerscores.flea_conn <- function(conn, page_limit = NULL, ...) {
     ) %>%
     dplyr::mutate(
       dplyr::across(
-        .cols = c("score_total", "score_avg", "score_sd"),
-        .fns = ~ purrr::map_dbl(.x, ~purrr::pluck(.x, "value", .default = NA) %>% round(2))
+        c("score_total", "score_avg", "score_sd"),
+        purrr::map_dbl,
+        ~ purrr::pluck(.x, "value", .default = NA) %>% round(2)
       ),
       games = (.data$score_total / .data$score_avg) %>% round()
     ) %>%

--- a/R/flea_rosters.R
+++ b/R/flea_rosters.R
@@ -19,7 +19,8 @@ ff_rosters.flea_conn <- function(conn, ...) {
   df_rosters <- fleaflicker_getendpoint("FetchLeagueRosters",
     sport = "NFL",
     external_id_type = "SPORTRADAR",
-    league_id = conn$league_id
+    league_id = conn$league_id,
+    season = conn$season
   ) %>%
     purrr::pluck("content", "rosters") %>%
     tibble::tibble() %>%


### PR DESCRIPTION
Add an additional function on flea_franchises.R called ff_franchises.flea_conn2 because ff_standings if the season hasn't started then it will give error, This gives that detail but even if the league hasn't started.

Added an additional functions to flea_starters.R ff_starters_detail.flea_conn to expand to include injury data. Also does not filter out players_ids that are NA. This will allow to see lineups were there is no player for example.