### PR TITLE
Add expanded function of flea ff_starters 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ffscrapr
 Title: API Client for Fantasy Football League Platforms
-Version: 1.4.8.05
+Version: 1.4.8.07
 Authors@R: 
     c(person(given = "Tan",
              family = "Ho",

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,14 @@ positions that did not have dedicated posititions (#400, thank you @mcarman8!)
 (v1.4.8.03)
 - `ff_scoring.mfl_conn()` now works better with new dplyr versions (#402) (v1.4.8.04)
 - `ff_schedule.mfl_conn()` bug fixed re: removing bad spreads (#403) (v1.4.8.05)
+- `ff_franchises.flea_conn` add season parameter to return franchises for other years
+but current year (v1.4.8.06)
+- `ff_playerscores.flea_conn` add season parameter to return player scores for other years
+but current year (v1.4.8.06)
+- `ff_rosters.flea_conn` add season parameter to return rosters for other years
+but current year (v1.4.8.06)
+- `ff_starters.flea_conn` expand starters to show injury data from box score and keep NA data
+where a player is not in a slot.  (v1.4.8.07)
 
 # ffscrapr 1.4.8
 

--- a/R/flea_rosters.R
+++ b/R/flea_rosters.R
@@ -18,7 +18,8 @@
 #' @export
 ff_rosters.flea_conn <- function(conn, week = NULL, ...) {
 
-  df_rosters <- fleaflicker_getendpoint("FetchLeagueRosters",
+  df_rosters <- fleaflicker_getendpoint(
+    "FetchLeagueRosters",
     sport = "NFL",
     external_id_type = "SPORTRADAR",
     league_id = conn$league_id,
@@ -32,7 +33,8 @@ ff_rosters.flea_conn <- function(conn, week = NULL, ...) {
     dplyr::select(-"team") %>%
     tidyr::unnest_longer("players") %>%
     tidyr::hoist("players", "proPlayer") %>%
-    tidyr::hoist("proPlayer",
+    tidyr::hoist(
+      "proPlayer",
       "player_id" = "id",
       "player_name" = "nameFull",
       "pos" = "position",
@@ -41,16 +43,18 @@ ff_rosters.flea_conn <- function(conn, week = NULL, ...) {
     ) %>%
     dplyr::mutate(
       sportradar_id = purrr::map_chr(.data$externalIds, purrr::pluck, 1, "id", .default = NA)
-      ) %>%
-    dplyr::select(dplyr::any_of(c(
-      "franchise_id",
-      "franchise_name",
-      "player_id",
-      "player_name",
-      "pos",
-      "team",
-      "sportradar_id"
-    )))
+    ) %>%
+    dplyr::select(
+      dplyr::any_of(c(
+        "franchise_id",
+        "franchise_name",
+        "player_id",
+        "player_name",
+        "pos",
+        "team",
+        "sportradar_id"
+      ))
+    )
 
   return(df_rosters)
 }

--- a/R/flea_starters.R
+++ b/R/flea_starters.R
@@ -68,3 +68,84 @@ ff_starters.flea_conn <- function(conn, week = 1:17, ...) {
 
   return(x)
 }
+
+####  Flea ff_starters Detail ####
+
+#' Get detail of starters and bench
+#'
+#' @param conn the list object created by `ff_connect()`
+#' @param week a numeric or numeric vector
+#' @param ... other arguments (currently unused)
+#'
+#' @describeIn ff_starters Fleaflicker Detail: returns a detailed version of flea_starters with injuries and no filters
+#'
+#' @examples
+#' \donttest{
+#' try({ # try only shown here because sometimes CRAN checks are weird
+#'   conn <- fleaflicker_connect(season = 2020, league_id = 206154)
+#'   ff_starters_detail.flea_conn(conn)
+#' }) # end try
+#' }
+ff_starters_detail.flea_conn <- function(conn, week = 1:17, ...) {
+  starters <- ff_schedule(conn, week) %>%
+    dplyr::filter(!is.na(.data$result)) %>%
+    dplyr::distinct(.data$week, .data$game_id) %>%
+    dplyr::mutate(starters = purrr::map2(.data$week, .data$game_id, .flea_starters_detail, conn)) %>%
+    tidyr::unnest("starters") %>%
+    dplyr::arrange(.data$week, .data$franchise_id)
+}
+
+.flea_starters_detail <- function(week, game_id, conn) {
+  cols <- c(injurytypeAbbreviaition = NA, injurytypeFull = NA, injurydescription = NA, injuryseverity = NA)
+  x <- fleaflicker_getendpoint("FetchLeagueBoxscore",
+                               sport = "NFL",
+                               scoring_period = week,
+                               fantasy_game_id = game_id,
+                               league_id = conn$league_id
+  ) |>
+    purrr::pluck("content", "lineups") |>
+    list() |>
+    tibble::tibble() |>
+    tidyr::unnest_longer(1) |>
+    tidyr::unnest_wider(1) |>
+    tidyr::unnest_longer("slots") |>
+    tidyr::unnest_wider("slots") |>
+    dplyr::mutate(
+      position = purrr::map_chr(.data$position, purrr::pluck, "label"),
+      positionColor = NULL
+    ) |>
+    tidyr::pivot_longer(c("home", "away"), names_to = "franchise", values_to = "player") |>
+    tidyr::hoist("player", "proPlayer", "owner", "points" = "viewingActualPoints") |>
+    tidyr::hoist("proPlayer",
+                 "player_id" = "id",
+                 "player_name" = "nameFull",
+                 "pos" = "position",
+                 "team" = "proTeamAbbreviation",
+                 "injury" = "injury"
+    ) |>
+    # dplyr::filter(!is.na(.data$player_id)) |>
+    tidyr::unnest_wider("injury", names_sep = "") |>
+    tidyr::hoist("owner", "franchise_id" = "id", "franchise_name" = "name") |>
+    tidyr::hoist("points", "player_score" = "value") |>
+    dplyr::mutate(group = dplyr::case_when(is.na(group) == TRUE ~ "BENCH", .default = group))
+  x = tibble::add_column(x, !!!cols[setdiff(names(cols), names(x))]) |>
+    dplyr::select(dplyr::any_of(c(
+      "group",
+      "franchise",
+      "franchise_id",
+      "franchise_name",
+      "starter_status" = "position",
+      "player_id",
+      "player_name",
+      "pos",
+      "team",
+      "injurytypeAbbreviaition",
+      "injurytypeFull",
+      "injurydescription",
+      "injuryseverity",
+      "player_score"
+    )))
+
+
+  return(x)
+}

--- a/R/flea_starters.R
+++ b/R/flea_starters.R
@@ -75,10 +75,10 @@ ff_starters.flea_conn <- function(conn, week = 1:17, ...) {
       "player_name",
       "pos",
       "team",
-      "injurytypeAbbreviaition",
-      "injurytypeFull",
-      "injurydescription",
-      "injuryseverity",
+      "injury_type_abbr" = "injurytypeAbbreviaition",
+      "injury_type" = "injurytypeFull",
+      "injury_desc" = "injurydescription",
+       "injury_severity" = "injuryseverity",
       "player_score"
     )))
 

--- a/R/flea_starters.R
+++ b/R/flea_starters.R
@@ -27,7 +27,12 @@ ff_starters.flea_conn <- function(conn, week = 1:17, ...) {
 }
 
 .flea_starters <- function(week, game_id, conn) {
-  cols <- c(injurytypeAbbreviaition = NA, injurytypeFull = NA, injurydescription = NA, injuryseverity = NA)
+  injury_cols <- data.frame(
+    injury_type_abbr = character(),
+    injury_type = character(),
+    injury_desc = character(),
+    injury_severity = character()
+   )
   x <- fleaflicker_getendpoint("FetchLeagueBoxscore",
                                sport = "NFL",
                                scoring_period = week,

--- a/R/flea_starters.R
+++ b/R/flea_starters.R
@@ -38,33 +38,31 @@ ff_starters.flea_conn <- function(conn, week = 1:17, ...) {
                                scoring_period = week,
                                fantasy_game_id = game_id,
                                league_id = conn$league_id
-  ) |>
-    purrr::pluck("content", "lineups") |>
-    list() |>
-    tibble::tibble() |>
-    tidyr::unnest_longer(1) |>
-    tidyr::unnest_wider(1) |>
-    tidyr::unnest_longer("slots") |>
-    tidyr::unnest_wider("slots") |>
+  ) %>%
+    purrr::pluck("content", "lineups") %>%
+    list() %>%
+    tibble::tibble() %>%
+    tidyr::unnest_longer(1) %>%
+    tidyr::unnest_wider(1) %>%
+    tidyr::unnest_longer("slots") %>%
+    tidyr::unnest_wider("slots") %>%
     dplyr::mutate(
       position = purrr::map_chr(.data$position, purrr::pluck, "label"),
       positionColor = NULL
-    ) |>
-    tidyr::pivot_longer(c("home", "away"), names_to = "franchise", values_to = "player") |>
-    tidyr::hoist("player", "proPlayer", "owner", "points" = "viewingActualPoints") |>
+    ) %>%
+    tidyr::pivot_longer(c("home", "away"), names_to = "franchise", values_to = "player") %>%
+    tidyr::hoist("player", "proPlayer", "owner", "points" = "viewingActualPoints") %>%
     tidyr::hoist("proPlayer",
                  "player_id" = "id",
                  "player_name" = "nameFull",
                  "pos" = "position",
                  "team" = "proTeamAbbreviation",
                  "injury" = "injury"
-    ) |>
-    # dplyr::filter(!is.na(.data$player_id)) |>
-    tidyr::unnest_wider("injury", names_sep = "") |>
-    tidyr::hoist("owner", "franchise_id" = "id", "franchise_name" = "name") |>
-    tidyr::hoist("points", "player_score" = "value") |>
-    dplyr::mutate(group = dplyr::case_when(is.na(group) == TRUE ~ "BENCH", .default = group))
-  x = tibble::add_column(x, !!!cols[setdiff(names(cols), names(x))]) |>
+    ) %>%
+    # dplyr::filter(!is.na(.data$player_id)) %>%
+    tidyr::unnest_wider("injury", names_sep = "") %>%
+    tidyr::hoist("owner", "franchise_id" = "id", "franchise_name" = "name") %>%
+    tidyr::hoist("points", "player_score" = "value") %>%
     dplyr::select(dplyr::any_of(c(
       "group",
       "franchise",

--- a/R/flea_starters.R
+++ b/R/flea_starters.R
@@ -27,75 +27,6 @@ ff_starters.flea_conn <- function(conn, week = 1:17, ...) {
 }
 
 .flea_starters <- function(week, game_id, conn) {
-  x <- fleaflicker_getendpoint("FetchLeagueBoxscore",
-    sport = "NFL",
-    scoring_period = week,
-    fantasy_game_id = game_id,
-    league_id = conn$league_id
-  ) %>%
-    purrr::pluck("content", "lineups") %>%
-    list() %>%
-    tibble::tibble() %>%
-    tidyr::unnest_longer(1) %>%
-    tidyr::unnest_wider(1) %>%
-    tidyr::unnest_longer("slots") %>%
-    tidyr::unnest_wider("slots") %>%
-    dplyr::mutate(
-      position = purrr::map_chr(.data$position, purrr::pluck, "label"),
-      positionColor = NULL
-    ) %>%
-    tidyr::pivot_longer(c("home", "away"), names_to = "franchise", values_to = "player") %>%
-    tidyr::hoist("player", "proPlayer", "owner", "points" = "viewingActualPoints") %>%
-    tidyr::hoist("proPlayer",
-      "player_id" = "id",
-      "player_name" = "nameFull",
-      "pos" = "position",
-      "team" = "proTeamAbbreviation"
-    ) %>%
-    dplyr::filter(!is.na(.data$player_id)) %>%
-    tidyr::hoist("owner", "franchise_id" = "id", "franchise_name" = "name") %>%
-    tidyr::hoist("points", "player_score" = "value") %>%
-    dplyr::select(dplyr::any_of(c(
-      "franchise_id",
-      "franchise_name",
-      "starter_status" = "position",
-      "player_id",
-      "player_name",
-      "pos",
-      "team",
-      "player_score"
-    )))
-
-  return(x)
-}
-
-####  Flea ff_starters Detail ####
-
-#' Get detail of starters and bench
-#'
-#' @param conn the list object created by `ff_connect()`
-#' @param week a numeric or numeric vector
-#' @param ... other arguments (currently unused)
-#'
-#' @describeIn ff_starters Fleaflicker Detail: returns a detailed version of flea_starters with injuries and no filters
-#'
-#' @examples
-#' \donttest{
-#' try({ # try only shown here because sometimes CRAN checks are weird
-#'   conn <- fleaflicker_connect(season = 2020, league_id = 206154)
-#'   ff_starters_detail.flea_conn(conn)
-#' }) # end try
-#' }
-ff_starters_detail.flea_conn <- function(conn, week = 1:17, ...) {
-  starters <- ff_schedule(conn, week) %>%
-    dplyr::filter(!is.na(.data$result)) %>%
-    dplyr::distinct(.data$week, .data$game_id) %>%
-    dplyr::mutate(starters = purrr::map2(.data$week, .data$game_id, .flea_starters_detail, conn)) %>%
-    tidyr::unnest("starters") %>%
-    dplyr::arrange(.data$week, .data$franchise_id)
-}
-
-.flea_starters_detail <- function(week, game_id, conn) {
   cols <- c(injurytypeAbbreviaition = NA, injurytypeFull = NA, injurydescription = NA, injuryseverity = NA)
   x <- fleaflicker_getendpoint("FetchLeagueBoxscore",
                                sport = "NFL",
@@ -146,6 +77,6 @@ ff_starters_detail.flea_conn <- function(conn, week = 1:17, ...) {
       "player_score"
     )))
 
-
   return(x)
 }
+

--- a/R/flea_starters.R
+++ b/R/flea_starters.R
@@ -80,7 +80,8 @@ ff_starters.flea_conn <- function(conn, week = 1:17, ...) {
       "injury_desc" = "injurydescription",
        "injury_severity" = "injuryseverity",
       "player_score"
-    )))
+    ))) %>%
+    dplyr::bind_rows(injury_cols)
 
   return(x)
 }


### PR DESCRIPTION
>Hmm. I'm not super sure that injuries would belong in ff_starters, but I think it's probably a good spot for this (unless injury status should actually go in ff_rosters for a given week?) .
>
>If it does end up here, I'd prefer to see this being added to the main ff_starters logic rather than as a separate function.


Added text from prior PR because I goofed up the fork by forgetting to commit to a new branch and just restarted everything over. 

So I looked at the ff_rosters and it does pull injury, but I think it is current inury as of now regardless of the season and week. Their is a scoring period parameter so currently the code will only pull week 1. So there is a roster call for each week. 

Pulling injury from the ff_starters which uses the box score is the way to go for injury designation it seems. ff_starters has the correct data but it isn't being pulled in which is what I did and removed the filter for players_id NA. I think having that unfiltered gives better context to who played and what the score was because it show the slots left open. 

I see the value of how you all have it, so it may warrant both or people can just add that filter themselves....lol. I think the filter, the injury fields, and adding BENCH to the group column is the only major changes.

Box score from Week 1 2022 shows Dak as Out and Kamara Q. This is what my detailed ff_starters shows, but ff_rosters using 2022 and week 1(local in R function and cran version) shows Dak with no injury and Kamara as Suspended.
https://www.fleaflicker.com/nfl/leagues/140956/scores/50886458
