### PR TITLE
bugfix: ff_scoringhistory - update internal nflreadr::load_rosters util 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ffscrapr
 Title: API Client for Fantasy Football League Platforms
-Version: 1.4.8.12
+Version: 1.4.8.13
 Authors@R: 
     c(person(given = "Tan",
              family = "Ho",

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@ and keep NA data where a player is not in a slot.  (v1.4.8.07)
 - Refactor testing
 - Bugfix sleeper draft picks using the wrong pick number (v1.4.8.11)
 - Bugfix espn starter positions to have proper total starters (v1.4.8.12) (#415)
+- Bugfix ff_scoringhistory to handle new-format `load_rosters()` now that it returns
+row per player-team-season (v1.4.8.13) (thanks @john-b-edwards!)
 
 # ffscrapr 1.4.8
 

--- a/R/1_nflverse.R
+++ b/R/1_nflverse.R
@@ -50,7 +50,8 @@
     ) %>%
     dplyr::group_by(season, gsis_id, sportradar_id) %>%
     dplyr::summarise(
-      dplyr::across(dplyr::everything(), dplyr::last)
+      dplyr::across(dplyr::everything(), dplyr::last),
+      .groups="drop"
     ) %>%
     dplyr::left_join(
       dp_playerids() %>%

--- a/R/1_nflverse.R
+++ b/R/1_nflverse.R
@@ -48,7 +48,7 @@
         "player_name"="full_name","pos"="position","team"
       ))
     ) %>%
-    dplyr::group_by(season, gsis_id, sportradar_id) %>%
+    dplyr::group_by(.data$season, .data$gsis_id, .data$sportradar_id) %>%
     dplyr::summarise(
       dplyr::across(dplyr::everything(), dplyr::last),
       .groups="drop"

--- a/R/1_nflverse.R
+++ b/R/1_nflverse.R
@@ -48,6 +48,10 @@
         "player_name"="full_name","pos"="position","team"
       ))
     ) %>%
+    dplyr::group_by(season, gsis_id, sportradar_id) %>%
+    dplyr::summarise(
+      dplyr::across(dplyr::everything(), dplyr::last)
+    ) %>%
     dplyr::left_join(
       dp_playerids() %>%
         dplyr::select("sportradar_id","mfl_id","sleeper_id","espn_id","fleaflicker_id"),


### PR DESCRIPTION
resolve issue counting twice players who appeared for multiple teams in a season. 

I think there might be some potential to formatting `team` as a list of teams played for e.g. `CAR/SF` instead of just the team they most recently played for, but this should be a quick fix.