### PR TITLE
Fix `ff_starters()` for multi-week playoff ESPN leagues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ffscrapr
 Title: API Client for Fantasy Football League Platforms
-Version: 1.4.8.14
+Version: 1.4.8.15
 Authors@R: 
     c(person(given = "Tan",
              family = "Ho",

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@ and keep NA data where a player is not in a slot.  (v1.4.8.07)
 - Bugfix ff_scoringhistory to handle new-format `load_rosters()` now that it returns
 row per player-team-season (v1.4.8.13) (thanks @john-b-edwards!)
 - Bugfix espn `ff_franchises()` to return coalesce of name/nickname (v1.4.8.14)
+- Bugfix espn `ff_starters()` to return handle multi-week formats (v1.4.8.15) (#421)
+(h/t @tonyelhabr 🤠)
 
 # ffscrapr 1.4.8
 

--- a/tests/testthat/test-ff_starters.R
+++ b/tests/testthat/test-ff_starters.R
@@ -32,3 +32,11 @@ test_that("ff_starters.espn finds the correct projected scores #397",{
   n_projection_equal_actual <- sum(s$player_score == s$projected_score & s$player_score!=0)
   expect_equal(n_projection_equal_actual, 0)
 })
+
+test_that("ff_starters.espn understands multi-week playoff formats #421",{
+  local_mock_api()
+  tony_conn <- espn_connect(season = 2022, league_id = 899513)
+  tony_starters <- ff_starters(tony_conn, weeks = 15:18)
+  expect_tibble(tony_starters, min.rows = 100)
+})
+


### PR DESCRIPTION
Fixes #421.

```r
packageVersion("ffscrapr")
#> [1] '1.4.8.15'
conn22 <- ffscrapr::espn_connect(
  season = 2022,
  league_id = 899513
)

## previously, this would error at index 16 (NFL week 16, second week of 1st round of playoffs)
starters22 <- ffscrapr::ff_starters(conn22, weeks = 1:18)
str(starters22, max.level = 1)
#> tibble [3,495 × 12] (S3: tbl_df/tbl/data.frame)

conn23 <- ffscrapr::espn_connect(
  season = 2023,
  league_id = 899513
)

## nothing broken for this year (no playoffs started)
starters23 <- ffscrapr::ff_starters(conn23, weeks = 1:18)
str(starters23, max.level = 1)
#> tibble [1,999 × 12] (S3: tbl_df/tbl/data.frame)
```