### PR TITLE
Fix max week in `ff_starters()` (ESPN)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ffscrapr
 Title: API Client for Fantasy Football League Platforms
-Version: 1.4.8.15
+Version: 1.4.8.16
 Authors@R: 
     c(person(given = "Tan",
              family = "Ho",

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ row per player-team-season (v1.4.8.13) (thanks @john-b-edwards!)
 - Bugfix espn `ff_franchises()` to return coalesce of name/nickname (v1.4.8.14)
 - Bugfix espn `ff_starters()` to return handle multi-week formats (v1.4.8.15) (#421)
 (h/t @tonyelhabr 🤠)
+- Bugfix espn `ff_starters()` to return less than or equal to max week (v1.4.8.16)
 
 # ffscrapr 1.4.8
 

--- a/R/espn_starters.R
+++ b/R/espn_starters.R
@@ -33,7 +33,7 @@ ff_starters.espn_conn <- function(conn, weeks = 1:17, ...) {
   week_matchup_periods_mapping <- .espn_week_matchup_periods_mapping(settings)
   max_week <- .espn_week_checkmax(settings)
 
-  run_weeks <- weeks[weeks < max_week]
+  run_weeks <- weeks[weeks <= max_week]
   named_run_weeks <- week_matchup_periods_mapping[run_weeks]
 
   if (length(run_weeks) == 0) {


### PR DESCRIPTION
Given the logic for [`ff_starters()` for Sleeper](https://github.com/ffverse/ffscrapr/blob/88d3e5148e95ec99c2db93422834cf3f21e670a8/R/sleeper_starters.R#L26) and the fact that I can't retrieve week 18 starter scores for my league last year (yes, we play through week 18 for some reason), I think `< max week` should be `<= max week`.