### PR TITLE
fixed ff_rosters() franchise_id for sleeper

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ffscrapr
 Title: API Client for Fantasy Football League Platforms
-Version: 1.4.8.18
+Version: 1.4.8.19
 Authors@R: 
     c(person(given = "Tan",
              family = "Ho",
@@ -57,5 +57,5 @@ LazyData: true
 VignetteBuilder:
     knitr
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@ row per player-team-season (v1.4.8.13) (thanks @john-b-edwards!)
 - Bugfix espn `ff_starters()` to return less than or equal to max week (v1.4.8.16)
 - [BREAKING] `mfl_players()` and `sleeper_players()` outputs now try to return
 more standardized column types (v1.4.8.17)
+- `sleeper_userleagues()` output has a new column roster_id which is the same ID as franchise_id in `sleeper_rosters()` (1.4.8.19) (#436)
 
 # ffscrapr 1.4.8
 

--- a/R/sleeper_rosters.R
+++ b/R/sleeper_rosters.R
@@ -24,7 +24,7 @@ ff_rosters.sleeper_conn <- function(conn, ...) {
   df_rosters <- sleeper_getendpoint(glue::glue("league/{conn$league_id}/rosters")) %>%
     purrr::pluck("content") %>%
     tibble::tibble() %>%
-    tidyr::hoist(1, "player_id" = "players", "franchise_id" = "roster_id") %>%
+    tidyr::hoist(1, "player_id" = "players", "franchise_id" = "owner_id") %>%
     tidyr::unnest("player_id") %>%
     dplyr::transmute(
       franchise_id = as.character(.data$franchise_id),

--- a/R/sleeper_rosters.R
+++ b/R/sleeper_rosters.R
@@ -24,7 +24,7 @@ ff_rosters.sleeper_conn <- function(conn, ...) {
   df_rosters <- sleeper_getendpoint(glue::glue("league/{conn$league_id}/rosters")) %>%
     purrr::pluck("content") %>%
     tibble::tibble() %>%
-    tidyr::hoist(1, "player_id" = "players", "franchise_id" = "owner_id") %>%
+    tidyr::hoist(1, "player_id" = "players", "franchise_id" = "roster_id") %>%
     tidyr::unnest("player_id") %>%
     dplyr::transmute(
       franchise_id = as.character(.data$franchise_id),

--- a/R/sleeper_userleagues.R
+++ b/R/sleeper_userleagues.R
@@ -37,7 +37,8 @@ ff_userleagues.sleeper_conn <- function(conn = NULL, user_name = NULL, season = 
     dplyr::mutate(
       league_id = as.character(league_id),
       franchise_name = purrr::map_chr(.data$league_id, .sleeper_userteams, user_id),
-      franchise_id = user_id
+      franchise_id = user_id,
+      roster_id = purrr::map_int(.data$league_id, .sleeper_rosterid, user_id)
     )
 
   return(df_leagues)
@@ -72,6 +73,20 @@ sleeper_userleagues <- function(user_name, season = NULL) {
     dplyr::mutate("franchise_name" = dplyr::coalesce(.data$franchise_name, .data$display_name)) %>%
     dplyr::filter(.data$franchise_id == user_id) %>%
     dplyr::pull("franchise_name")
+
+  return(df_teams)
+}
+
+#' Get Roster ID
+#' @noRd
+
+.sleeper_rosterid <- function(league_id, user_id) {
+  df_teams <- sleeper_getendpoint(glue::glue("league/{league_id}/rosters")) %>%
+    purrr::pluck("content") %>%
+    tibble::tibble() %>%
+    tidyr::hoist(1, "owner_id", "roster_id") %>%
+    dplyr::filter(.data$owner_id == user_id) %>%
+    dplyr::pull("roster_id")
 
   return(df_teams)
 }


### PR DESCRIPTION
closes #435 

- replaced roster_id with owner_id from sleeper api

idk if it's the way you want to go. maybe add a second column istead of replace the old one? but i think that would not be coherent with the other platforms.