### PR TITLE
added league_type = contest to mfl_league

### DIFF
--- a/R/mfl_league.R
+++ b/R/mfl_league.R
@@ -55,7 +55,11 @@ ff_league.mfl_conn <- function(conn) {
 .mfl_league_type <- function(league_endpoint) {
   x <- league_endpoint[["keeperType"]]
   if (is.null(x)) {
-    return(NA_character_)
+    x <- league_endpoint[["loadRosters"]]
+
+    if (x != "contest") {
+      return(NA_character_)
+    }
   }
   if (x == "none") x <- "redraft"
   x


### PR DESCRIPTION
I'm playing in a mfl contest league and thought, it would be usefull to get this type via `mfl_league()`.

For that, I use the API endpoint `loadRosters` if no `keeperType` is found. I don't know, how robust this is and if someone is playing a keeper contest league or if this is even possible. But maybe this is better than nothing?